### PR TITLE
2 bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v1.13.2 / 2016 May 17
+
+> Bug in `LoanDataUtils` - `PostClosingConditions` were being cast as `UnderwritingConditions`
+
+* **Fix** - Fixed invalid object casting in `LoanDataUtils`
+
+```c#
+[GuaranteedRate.Sextant "1.13.2"]
+```
+
 ## v1.13.1 / 2016 May 2
 
 > Switched back to `EncompassSDK.Complete`, `EncompassSDK.Standard` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v1.13.1 / 2016 May 2
+
+> Switched back to `EncompassSDK.Complete`, `EncompassSDK.Standard` is
+> insufficient for SDK apps.
+
+* **Fix** - Switched back from EncompassSDK.Standard to EncompassSDK.Complete.  
+Standard isn't sufficient for standalone apps.
+
+```c#
+[GuaranteedRate.Sextant "1.13.1"]
+```
+
 ## v1.13.0 / 2016 April 22
 
 > Collection of improvements to handle Encompass Performance issues being 

--- a/GuaranteedRate.Examples.FieldUtils/GuaranteedRate.Examples.FieldUtils.csproj
+++ b/GuaranteedRate.Examples.FieldUtils/GuaranteedRate.Examples.FieldUtils.csproj
@@ -33,21 +33,113 @@
     <StartupObject>GuaranteedRate.Examples.FieldUtils.FieldDescriptions</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Client, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientCommon, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientCommon.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientServer, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientSession, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientSession.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DataAccess, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\DataAccess.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DocumentConverter, Version=7.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\DocumentConverter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EllieMae.Encompass.AsmResolver, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EllieMae.Encompass.AsmResolver.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EllieMae.Encompass.AsmResolver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EllieMae.Encompass.Runtime, Version=3.5.1.5, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EllieMae.Encompass.Runtime.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EllieMae.Encompass.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMBAM15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMBAM15.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMCommon, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMCommon.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMExport, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMExport.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMLoanUtils15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMLoanUtils15.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EncompassAutomation, Version=15.2.0.6, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EncompassAutomation.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EncompassAutomation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EncompassObjects, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EncompassObjects.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EncompassObjects.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GenuineChannels, Version=2.4.3.54, Culture=neutral, PublicKeyToken=65fda4a3fde44959, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\GenuineChannels.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.84.0.0, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Import, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Import.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Shared.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Shared.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Win.UltraWinSchedule.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Win.UltraWinSchedule.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Win.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Win.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="itextsharp, Version=5.0.2.0, Culture=neutral, PublicKeyToken=8354ae6d2174ddca, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\itextsharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Jed, Version=1.0.1234.56789, Culture=neutral, PublicKeyToken=d11ef57bba4acf91">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Jed.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PostSharp, Version=3.1.41.9, Culture=neutral, PublicKeyToken=b13fd38b8f9c99d7, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\PostSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ReportingDbUtils, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ReportingDbUtils.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SDKConfigImpl, Version=15.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\SDKConfigImpl.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Server, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Server.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SharpZipLib, Version=0.4.0.0, Culture=neutral, PublicKeyToken=fbebc9694da332b7">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\SharpZipLib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -56,6 +148,14 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="VersionInterface15, Version=1.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\VersionInterface15.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xml3WayMerge, Version=6.2.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Xml3WayMerge.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FieldUtils.cs" />

--- a/GuaranteedRate.Examples.FieldUtils/packages.config
+++ b/GuaranteedRate.Examples.FieldUtils/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EncompassSDK.Standard" version="15.2.0" targetFramework="net45" />
+  <package id="EncompassSdk.Complete" version="15.2.0" targetFramework="net45" />
 </packages>

--- a/GuaranteedRate.Examples.LoanDataUtils/GuaranteedRate.Examples.LoanDataUtils.csproj
+++ b/GuaranteedRate.Examples.LoanDataUtils/GuaranteedRate.Examples.LoanDataUtils.csproj
@@ -33,25 +33,117 @@
     <StartupObject>GuaranteedRate.Examples.LoanDataUtils.LoanExtractor</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Client, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientCommon, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientCommon.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientServer, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientSession, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientSession.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DataAccess, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\DataAccess.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DocumentConverter, Version=7.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\DocumentConverter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EllieMae.Encompass.AsmResolver, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EllieMae.Encompass.AsmResolver.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EllieMae.Encompass.AsmResolver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EllieMae.Encompass.Runtime, Version=3.5.1.5, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EllieMae.Encompass.Runtime.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EllieMae.Encompass.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMBAM15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMBAM15.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMCommon, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMCommon.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMExport, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMExport.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMLoanUtils15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMLoanUtils15.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EncompassAutomation, Version=15.2.0.6, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EncompassAutomation.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EncompassAutomation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EncompassObjects, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EncompassObjects.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EncompassObjects.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GenuineChannels, Version=2.4.3.54, Culture=neutral, PublicKeyToken=65fda4a3fde44959, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\GenuineChannels.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.84.0.0, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Import, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Import.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Shared.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Shared.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Win.UltraWinSchedule.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Win.UltraWinSchedule.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Win.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Win.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="itextsharp, Version=5.0.2.0, Culture=neutral, PublicKeyToken=8354ae6d2174ddca, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\itextsharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Jed, Version=1.0.1234.56789, Culture=neutral, PublicKeyToken=d11ef57bba4acf91">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Jed.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="PostSharp, Version=3.1.41.9, Culture=neutral, PublicKeyToken=b13fd38b8f9c99d7, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\PostSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ReportingDbUtils, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ReportingDbUtils.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SDKConfigImpl, Version=15.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\SDKConfigImpl.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Server, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Server.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SharpZipLib, Version=0.4.0.0, Culture=neutral, PublicKeyToken=fbebc9694da332b7">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\SharpZipLib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -60,6 +152,14 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="VersionInterface15, Version=1.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\VersionInterface15.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xml3WayMerge, Version=6.2.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Xml3WayMerge.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="LoanExtractor.cs" />

--- a/GuaranteedRate.Examples.LoanDataUtils/packages.config
+++ b/GuaranteedRate.Examples.LoanDataUtils/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EncompassSDK.Standard" version="15.2.0" targetFramework="net45" />
+  <package id="EncompassSdk.Complete" version="15.2.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/GuaranteedRate.Examples.ReportingUtils/GuaranteedRate.Examples.ReportingUtils.csproj
+++ b/GuaranteedRate.Examples.ReportingUtils/GuaranteedRate.Examples.ReportingUtils.csproj
@@ -33,21 +33,113 @@
     <StartupObject>GuaranteedRate.Examples.ReportingUtils.ReportingExample</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Client, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientCommon, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientCommon.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientServer, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientSession, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientSession.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DataAccess, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\DataAccess.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DocumentConverter, Version=7.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\DocumentConverter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EllieMae.Encompass.AsmResolver, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EllieMae.Encompass.AsmResolver.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EllieMae.Encompass.AsmResolver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EllieMae.Encompass.Runtime, Version=3.5.1.5, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EllieMae.Encompass.Runtime.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EllieMae.Encompass.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMBAM15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMBAM15.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMCommon, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMCommon.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMExport, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMExport.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMLoanUtils15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMLoanUtils15.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EncompassAutomation, Version=15.2.0.6, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EncompassAutomation.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EncompassAutomation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EncompassObjects, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EncompassObjects.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EncompassObjects.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GenuineChannels, Version=2.4.3.54, Culture=neutral, PublicKeyToken=65fda4a3fde44959, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\GenuineChannels.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.84.0.0, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Import, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Import.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Shared.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Shared.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Win.UltraWinSchedule.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Win.UltraWinSchedule.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Win.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Win.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="itextsharp, Version=5.0.2.0, Culture=neutral, PublicKeyToken=8354ae6d2174ddca, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\itextsharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Jed, Version=1.0.1234.56789, Culture=neutral, PublicKeyToken=d11ef57bba4acf91">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Jed.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PostSharp, Version=3.1.41.9, Culture=neutral, PublicKeyToken=b13fd38b8f9c99d7, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\PostSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ReportingDbUtils, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ReportingDbUtils.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SDKConfigImpl, Version=15.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\SDKConfigImpl.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Server, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Server.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SharpZipLib, Version=0.4.0.0, Culture=neutral, PublicKeyToken=fbebc9694da332b7">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\SharpZipLib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -56,6 +148,14 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="VersionInterface15, Version=1.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\VersionInterface15.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xml3WayMerge, Version=6.2.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Xml3WayMerge.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ReportingExample.cs" />

--- a/GuaranteedRate.Examples.ReportingUtils/packages.config
+++ b/GuaranteedRate.Examples.ReportingUtils/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EncompassSDK.Standard" version="15.2.0" targetFramework="net45" />
+  <package id="EncompassSdk.Complete" version="15.2.0" targetFramework="net45" />
 </packages>

--- a/GuaranteedRate.Examples.UserUtils/GuaranteedRate.Examples.UserUtils.csproj
+++ b/GuaranteedRate.Examples.UserUtils/GuaranteedRate.Examples.UserUtils.csproj
@@ -34,21 +34,113 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Client, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientCommon, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientCommon.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientServer, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientSession, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientSession.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DataAccess, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\DataAccess.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DocumentConverter, Version=7.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\DocumentConverter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EllieMae.Encompass.AsmResolver, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EllieMae.Encompass.AsmResolver.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EllieMae.Encompass.AsmResolver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EllieMae.Encompass.Runtime, Version=3.5.1.5, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EllieMae.Encompass.Runtime.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EllieMae.Encompass.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMBAM15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMBAM15.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMCommon, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMCommon.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMExport, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMExport.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMLoanUtils15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMLoanUtils15.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EncompassAutomation, Version=15.2.0.6, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EncompassAutomation.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EncompassAutomation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EncompassObjects, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EncompassObjects.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EncompassObjects.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GenuineChannels, Version=2.4.3.54, Culture=neutral, PublicKeyToken=65fda4a3fde44959, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\GenuineChannels.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.84.0.0, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Import, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Import.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Shared.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Shared.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Win.UltraWinSchedule.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Win.UltraWinSchedule.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Win.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Win.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="itextsharp, Version=5.0.2.0, Culture=neutral, PublicKeyToken=8354ae6d2174ddca, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\itextsharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Jed, Version=1.0.1234.56789, Culture=neutral, PublicKeyToken=d11ef57bba4acf91">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Jed.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PostSharp, Version=3.1.41.9, Culture=neutral, PublicKeyToken=b13fd38b8f9c99d7, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\PostSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ReportingDbUtils, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ReportingDbUtils.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SDKConfigImpl, Version=15.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\SDKConfigImpl.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Server, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Server.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SharpZipLib, Version=0.4.0.0, Culture=neutral, PublicKeyToken=fbebc9694da332b7">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\SharpZipLib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -58,6 +150,14 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="VersionInterface15, Version=1.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\VersionInterface15.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xml3WayMerge, Version=6.2.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Xml3WayMerge.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/GuaranteedRate.Examples.UserUtils/packages.config
+++ b/GuaranteedRate.Examples.UserUtils/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EncompassSDK.Standard" version="15.2.0" targetFramework="net45" />
+  <package id="EncompassSdk.Complete" version="15.2.0" targetFramework="net45" />
 </packages>

--- a/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
@@ -319,7 +319,7 @@ namespace GuaranteedRate.Sextant.EncompassUtils
         {
             IList<string> keys = new List<string>();
             
-            foreach (UnderwritingCondition cond in currentLoan.Log.PostClosingConditions)
+            foreach (PostClosingCondition cond in currentLoan.Log.PostClosingConditions)
             {
                 keys.Add(cond.Title);
             }

--- a/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
+++ b/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
@@ -30,25 +30,117 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Client, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientCommon, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientCommon.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientServer, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientSession, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientSession.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DataAccess, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\DataAccess.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DocumentConverter, Version=7.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\DocumentConverter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EllieMae.Encompass.AsmResolver, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EllieMae.Encompass.AsmResolver.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EllieMae.Encompass.AsmResolver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EllieMae.Encompass.Runtime, Version=3.5.1.5, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EllieMae.Encompass.Runtime.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EllieMae.Encompass.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMBAM15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMBAM15.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMCommon, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMCommon.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMExport, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMExport.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMLoanUtils15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMLoanUtils15.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EncompassAutomation, Version=15.2.0.6, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EncompassAutomation.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EncompassAutomation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EncompassObjects, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EncompassObjects.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EncompassObjects.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GenuineChannels, Version=2.4.3.54, Culture=neutral, PublicKeyToken=65fda4a3fde44959, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\GenuineChannels.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.84.0.0, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Import, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Import.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Shared.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Shared.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Win.UltraWinSchedule.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Win.UltraWinSchedule.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Win.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Win.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="itextsharp, Version=5.0.2.0, Culture=neutral, PublicKeyToken=8354ae6d2174ddca, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\itextsharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Jed, Version=1.0.1234.56789, Culture=neutral, PublicKeyToken=d11ef57bba4acf91">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Jed.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="PostSharp, Version=3.1.41.9, Culture=neutral, PublicKeyToken=b13fd38b8f9c99d7, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\PostSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ReportingDbUtils, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ReportingDbUtils.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SDKConfigImpl, Version=15.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\SDKConfigImpl.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Server, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Server.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SharpZipLib, Version=0.4.0.0, Culture=neutral, PublicKeyToken=fbebc9694da332b7">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\SharpZipLib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -57,6 +149,14 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="VersionInterface15, Version=1.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\VersionInterface15.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xml3WayMerge, Version=6.2.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Xml3WayMerge.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Config\IEncompassConfig.cs" />

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.13.0.0")]
-[assembly: AssemblyFileVersion("1.13.0.0")]
+[assembly: AssemblyVersion("1.13.1.0")]
+[assembly: AssemblyFileVersion("1.13.1.0")]

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.13.1.0")]
-[assembly: AssemblyFileVersion("1.13.1.0")]
+[assembly: AssemblyVersion("1.13.2.0")]
+[assembly: AssemblyFileVersion("1.13.2.0")]

--- a/GuaranteedRate.Sextant/packages.config
+++ b/GuaranteedRate.Sextant/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EncompassSDK.Standard" version="15.2.0" targetFramework="net45" />
+  <package id="EncompassSdk.Complete" version="15.2.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/GuaranteedRate.Util.IndexFields/GuaranteedRate.Util.IndexFields.csproj
+++ b/GuaranteedRate.Util.IndexFields/GuaranteedRate.Util.IndexFields.csproj
@@ -32,21 +32,113 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Client, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientCommon, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientCommon.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientServer, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientSession, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ClientSession.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DataAccess, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\DataAccess.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DocumentConverter, Version=7.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\DocumentConverter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EllieMae.Encompass.AsmResolver, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EllieMae.Encompass.AsmResolver.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EllieMae.Encompass.AsmResolver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EllieMae.Encompass.Runtime, Version=3.5.1.5, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EllieMae.Encompass.Runtime.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EllieMae.Encompass.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMBAM15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMBAM15.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMCommon, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMCommon.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMExport, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMExport.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EMLoanUtils15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EMLoanUtils15.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EncompassAutomation, Version=15.2.0.6, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EncompassAutomation.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EncompassAutomation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EncompassObjects, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EncompassSDK.Standard.15.2.0\lib\EncompassObjects.dll</HintPath>
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\EncompassObjects.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GenuineChannels, Version=2.4.3.54, Culture=neutral, PublicKeyToken=65fda4a3fde44959, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\GenuineChannels.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.84.0.0, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Import, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Import.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Shared.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Shared.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Win.UltraWinSchedule.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Win.UltraWinSchedule.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Infragistics2.Win.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Infragistics2.Win.v7.1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="itextsharp, Version=5.0.2.0, Culture=neutral, PublicKeyToken=8354ae6d2174ddca, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\itextsharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Jed, Version=1.0.1234.56789, Culture=neutral, PublicKeyToken=d11ef57bba4acf91">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Jed.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PostSharp, Version=3.1.41.9, Culture=neutral, PublicKeyToken=b13fd38b8f9c99d7, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\PostSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ReportingDbUtils, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\ReportingDbUtils.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SDKConfigImpl, Version=15.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\SDKConfigImpl.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Server, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Server.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SharpZipLib, Version=0.4.0.0, Culture=neutral, PublicKeyToken=fbebc9694da332b7">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\SharpZipLib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -55,6 +147,14 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="VersionInterface15, Version=1.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\VersionInterface15.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xml3WayMerge, Version=6.2.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSdk.Complete.15.2.0\lib\Xml3WayMerge.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MultiIndexFinder.cs" />

--- a/GuaranteedRate.Util.IndexFields/packages.config
+++ b/GuaranteedRate.Util.IndexFields/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EncompassSDK.Standard" version="15.2.0" targetFramework="net45" />
+  <package id="EncompassSdk.Complete" version="15.2.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
1. Switched back to the full sdk, console apps had problems without it
2. In GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs there was a copy/paste error which caused an object to be cast wrong