### PR TITLE
make IDataDogReporter public so clients can do dependency injection.

### DIFF
--- a/GuaranteedRate.Sextant/Metrics/IDataDogReporter.cs
+++ b/GuaranteedRate.Sextant/Metrics/IDataDogReporter.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace GuaranteedRate.Sextant.Metrics
 {
-    interface IDataDogReporter
+    public interface IDataDogReporter
     {
         void AddCounter(string metric, long value);
          

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("16.2.0.0")]
-[assembly: AssemblyFileVersion("16.2.0.0")]
+[assembly: AssemblyVersion("16.2.0.1")]
+[assembly: AssemblyFileVersion("16.2.0.1")]


### PR DESCRIPTION
I want to have my clients use the interface so we can have a Mock<IDataDogReporter> in our test code.

