### PR TITLE
Server sig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## v16.2.1.0 / 2016 July 18
+
+> Added the server URI and smart client to the list of fields collected by
+> `LoanDataUtils`, which is useful for users supporting mutliple Encompass 
+> Environments
+
+* **Add** - `Session.ServerURI` as `SessionServerURI` to the Loan Dictonary 
+created by LoanDataUtils.
+* **Add** - `smart client id` as `SessionSmartClientId` to the Loan Dictonary 
+created by LoanDataUtils.  This value is derived from the ServerURI.
+
+```c#
+[GuaranteedRate.Sextant "16.2.1.0"]
+```
+
 ## v16.2.0.0 / 2016 July 7
 
 > Changing the versioning scheme to match Ellie Mae.

--- a/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
@@ -133,6 +133,9 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                 Session session = loan.Session;
                 if (session != null) 
                 {
+                    string serverUri = session.ServerURI;
+                    fieldValues.Add("SessionServerURI", serverUri); //https://smartClientId.ea.elliemae.net$smartClientId
+                    fieldValues.Add("SessionSmartClientId", serverUri.Substring(serverUri.IndexOf("$")));   //just the smartClientId
                     fieldValues.Add("SessionUserId", session.UserID);
                 }
             }

--- a/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
@@ -135,7 +135,7 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                 {
                     string serverUri = session.ServerURI;
                     fieldValues.Add("SessionServerURI", serverUri); //https://smartClientId.ea.elliemae.net$smartClientId
-                    fieldValues.Add("SessionSmartClientId", serverUri.Substring(serverUri.IndexOf("$")));   //just the smartClientId
+                    fieldValues.Add("SessionSmartClientId", serverUri.Substring(serverUri.IndexOf("$") + 1));   //just the smartClientId
                     fieldValues.Add("SessionUserId", session.UserID);
                 }
             }

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("16.2.0.0")]
-[assembly: AssemblyFileVersion("16.2.0.0")]
+[assembly: AssemblyVersion("16.2.1.0")]
+[assembly: AssemblyFileVersion("16.2.1.0")]


### PR DESCRIPTION
We've had a periodic problem with data getting saved across environments.  I've added a Blacklist to Peck that will reject loans with a `SessionSmartClientId` from the wrong environment.

This update to Sextant will add the server signature to loan data so that the blacklist will work.

@KseniaLaney @brianbegygr @MaxReznik @antonmos @ncapetillo-gr @KirillMedvedevGR 