### PR TITLE
Forcing trimming on FieldIds before lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v17.1.0.1 / 2017 Feb 23
+> This release forces trimming on field ids to prevent Encompass "Field ID not found" errors 
+
 ## v17.1.0.0 / 2017 Feb 08
 > This release updates the Encompass SDK to version 17.1 and includes instructions 
 > for building your own NuGet package.

--- a/GuaranteedRate.Sextant/EncompassUtils/FieldUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/FieldUtils.cs
@@ -765,7 +765,8 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                 }
                 else
                 {
-                    Loggly.Error("FieldUtils", $"Duplicate field Ids ({fieldDescriptor.FieldID}) found in GetAllFieldDescriptors");
+                    Loggly.Error("FieldUtils", $"Duplicate field Ids ({fieldDescriptor.FieldID}) found in GetAllFieldDescriptors. "+ 
+                        $"Existing value: {fieldsAndDescriptions[fieldDescriptor.FieldID]}, New value: {fieldDescriptor.Description}");
                 }
             }
 

--- a/GuaranteedRate.Sextant/EncompassUtils/FieldUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/FieldUtils.cs
@@ -5,6 +5,7 @@ using EllieMae.Encompass.Collections;
 using EllieMae.Encompass.Reporting;
 using System;
 using System.Collections.Generic;
+using GuaranteedRate.Sextant.Loggers;
 
 namespace GuaranteedRate.Sextant.EncompassUtils
 {
@@ -441,22 +442,23 @@ namespace GuaranteedRate.Sextant.EncompassUtils
             MORTGAGES_MULTI_KEYS = new HashSet<string>();
             VESTING_MULTI_KEYS = new HashSet<string>();
 
-            INDEX_MULTI_SORTER = new Dictionary<string, ISet<string>>();
-            INDEX_MULTI_SORTER.Add(BORROWER_EMPLOYERS_STARTS, BORROWER_EMPLOYERS_MULTI_KEYS);
-            INDEX_MULTI_SORTER.Add(CO_BORROWER_EMPLOYERS_STARTS, CO_BORROWER_EMPLOYERS_MULTI_KEYS);
-            INDEX_MULTI_SORTER.Add(BORROWER_RESIDENCES_STARTS, BORROWER_RESIDENCES_MULTI_KEYS);
-            INDEX_MULTI_SORTER.Add(CO_BORROWER_RESIDENCES_STARTS, CO_BORROWER_RESIDENCES_MULTI_KEYS);
-            INDEX_MULTI_SORTER.Add(FD_DEPOSITS_STARTS, DEPOSITS_MULTI_KEYS);
-            INDEX_MULTI_SORTER.Add(DD_DEPOSITS_STARTS, DEPOSITS_MULTI_KEYS);
-            INDEX_MULTI_SORTER.Add(FL_LIABILITIES_STARTS, LIABILITIES_MULTI_KEYS);
-            INDEX_MULTI_SORTER.Add(MORTGAGES_STARTS, MORTGAGES_MULTI_KEYS);
-            INDEX_MULTI_SORTER.Add(IRS_MORTGAGE_INFO_STARTS, MORTGAGES_MULTI_KEYS);
-            INDEX_MULTI_SORTER.Add(VESTING_PARITIES_STARTS, VESTING_MULTI_KEYS);
+            INDEX_MULTI_SORTER = new Dictionary<string, ISet<string>>
+            {
+                {BORROWER_EMPLOYERS_STARTS, BORROWER_EMPLOYERS_MULTI_KEYS},
+                {CO_BORROWER_EMPLOYERS_STARTS, CO_BORROWER_EMPLOYERS_MULTI_KEYS},
+                {BORROWER_RESIDENCES_STARTS, BORROWER_RESIDENCES_MULTI_KEYS},
+                {CO_BORROWER_RESIDENCES_STARTS, CO_BORROWER_RESIDENCES_MULTI_KEYS},
+                {FD_DEPOSITS_STARTS, DEPOSITS_MULTI_KEYS},
+                {DD_DEPOSITS_STARTS, DEPOSITS_MULTI_KEYS},
+                {FL_LIABILITIES_STARTS, LIABILITIES_MULTI_KEYS},
+                {MORTGAGES_STARTS, MORTGAGES_MULTI_KEYS},
+                {IRS_MORTGAGE_INFO_STARTS, MORTGAGES_MULTI_KEYS},
+                {VESTING_PARITIES_STARTS, VESTING_MULTI_KEYS}
+            };
 
             DISCLOSURES_MULTI_KEYS = new HashSet<string>();
 
-            INDEX_MULTI_SORTER_END = new Dictionary<string, ISet<string>>();
-            INDEX_MULTI_SORTER_END.Add(DISCLOSURES_STARTS, DISCLOSURES_MULTI_KEYS);
+            INDEX_MULTI_SORTER_END = new Dictionary<string, ISet<string>> {{DISCLOSURES_STARTS, DISCLOSURES_MULTI_KEYS}};
 
             ROLE_MULTI_KEYS = GetRoleMultiKeys();
             MILESTONE_MULTI_KEYS = GetMilestoneMultiKeys();
@@ -559,17 +561,21 @@ namespace GuaranteedRate.Sextant.EncompassUtils
         {
             foreach (FieldDescriptor fieldDescriptor in fieldDescriptors)
             {
+                if (string.IsNullOrEmpty(fieldDescriptor.FieldID)) continue;
+
+                var baseKey = fieldDescriptor.FieldID.Trim();
+
                 if (!fieldDescriptor.MultiInstance)
                 {
-                    SIMPLE_FIELDS.Add(fieldDescriptor.FieldID);
+                    SIMPLE_FIELDS.Add(baseKey);
                 }
                 else
                 {
                     switch (fieldDescriptor.InstanceSpecifierType)
                     {
                         case MultiInstanceSpecifierType.Index:
-                            string starts2 = fieldDescriptor.FieldID.Substring(0, 2);
-                            string starts3 = fieldDescriptor.FieldID.Substring(0, 3);
+                            string starts2 = baseKey.Substring(0, 2);
+                            string starts3 = baseKey.Substring(0, 3);
                             /**
                              * These 3 groups do not follow any known rules for extraction
                              * have no descriptions, and seem to consist of dupe data.
@@ -579,17 +585,17 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                             if (starts2 != "LP" && starts3 != "FBE" && starts3 != "FCE")
                             {
                                 //the < 30 is to skip DISCLOSEDGFE.Snapshot.NEWHUD.X100...
-                                if (fieldDescriptor.FieldID.Contains("00") && fieldDescriptor.FieldID.Length < 30)
+                                if (baseKey.Contains("00") && baseKey.Length < 30)
                                 {
-                                    string key = fieldDescriptor.FieldID.Substring(0, 2);
+                                    string key = baseKey.Substring(0, 2);
                                     if (INDEX_MULTI_SORTER.Keys.Contains(key))
                                     {
-                                        INDEX_MULTI_SORTER[key].Add(fieldDescriptor.FieldID);
+                                        INDEX_MULTI_SORTER[key].Add(baseKey);
                                     }
                                     else
                                     {
                                         UNKNOWN_KEYS.Add(key);
-                                        MIDDLE_INDEXED.Add(fieldDescriptor.FieldID);
+                                        MIDDLE_INDEXED.Add(baseKey);
                                     }
                                 }
                                 else
@@ -597,37 +603,37 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                                     bool matched = false;
                                     foreach (string key in INDEX_MULTI_SORTER_END.Keys)
                                     {
-                                        if (fieldDescriptor.FieldID.StartsWith(key))
+                                        if (baseKey.StartsWith(key))
                                         {
-                                            INDEX_MULTI_SORTER_END[key].Add(fieldDescriptor.FieldID);
+                                            INDEX_MULTI_SORTER_END[key].Add(baseKey);
                                             matched = true;
                                             break;
                                         }
                                     }
                                     if (!matched)
                                     {
-                                        END_INDEXED.Add(fieldDescriptor.FieldID);
+                                        END_INDEXED.Add(baseKey);
                                     }
                                 }
                             }
                             break;
                         case MultiInstanceSpecifierType.Document:
-                            DOCUMENT_MULTI.Add(fieldDescriptor.FieldID);
+                            DOCUMENT_MULTI.Add(baseKey);
                             break;
                         case MultiInstanceSpecifierType.Milestone:
-                            UnrollMultiFieldIds(fieldDescriptor.FieldID, MILESTONE_MULTI_KEYS);
+                            UnrollMultiFieldIds(baseKey, MILESTONE_MULTI_KEYS);
                             break;
                         case MultiInstanceSpecifierType.MilestoneTask:
-                            MILESTONE_TASK_MULTI.Add(fieldDescriptor.FieldID);
+                            MILESTONE_TASK_MULTI.Add(baseKey);
                             break;
                         case MultiInstanceSpecifierType.PostClosingCondition:
-                            POST_CLOSING_CONDITION_MULTI.Add(fieldDescriptor.FieldID);
+                            POST_CLOSING_CONDITION_MULTI.Add(baseKey);
                             break;
                         case MultiInstanceSpecifierType.Role:
-                            UnrollMultiFieldIds(fieldDescriptor.FieldID, ROLE_MULTI_KEYS);
+                            UnrollMultiFieldIds(baseKey, ROLE_MULTI_KEYS);
                             break;
                         case MultiInstanceSpecifierType.UnderwritingCondition:
-                            UNDERWRITING_MULTI.Add(fieldDescriptor.FieldID);
+                            UNDERWRITING_MULTI.Add(baseKey);
                             break;
                         default:
                             break;
@@ -751,10 +757,18 @@ namespace GuaranteedRate.Sextant.EncompassUtils
             IDictionary<string, string> fieldsAndDescriptions = new Dictionary<string, string>();
             ISet<FieldDescriptor> fieldDescriptorsList = Instance.GetAllFieldDescriptors();
 
-            foreach (FieldDescriptor fieldDescriptor in fieldDescriptorsList)
+            foreach (var fieldDescriptor in fieldDescriptorsList)
             {
-                fieldsAndDescriptions.Add(fieldDescriptor.FieldID, fieldDescriptor.Description);
+                if (!fieldsAndDescriptions.ContainsKey(fieldDescriptor.FieldID))
+                {
+                    fieldsAndDescriptions.Add(fieldDescriptor.FieldID, fieldDescriptor.Description);
+                }
+                else
+                {
+                    Loggly.Error("FieldUtils", $"Duplicate field Ids ({fieldDescriptor.FieldID}) found in GetAllFieldDescriptors");
+                }
             }
+
             return fieldsAndDescriptions;
         }
 

--- a/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
@@ -485,12 +485,8 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                         string val = ExtractSimpleField(currentLoan, fullKey);
                         try
                         {
-                            if (val != null)
-                            {
-                                var insertKey = SafeFieldId(fullKey);
-
-                                fieldDictionary[insertKey] = val;
-                            }
+                            var insertKey = SafeFieldId(fullKey);
+                            fieldDictionary[insertKey] = val;
                         }
                         catch (Exception ex)
                         {

--- a/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
@@ -5,7 +5,6 @@ using GuaranteedRate.Sextant.Loggers;
 using GuaranteedRate.Sextant.Models;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace GuaranteedRate.Sextant.EncompassUtils
 {
@@ -491,8 +490,7 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                         catch (Exception ex)
                         {
                             Loggly.Warn("LoandataUtils",
-                                $"Error extracting field {fullKey} from loan #:{loanNumber} loan guid:{currentLoan.Guid}" +
-                                ex);
+                                $"Error extracting field {fullKey} from loan #:{loanNumber} loan guid:{currentLoan.Guid} Exception:{ex}");
                         }
                     }
                 }
@@ -527,15 +525,7 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                             if (value != null)
                             {
                                 var key = SafeFieldId(fieldIdIndex);
-
-                                if (fieldDictionary.ContainsKey(key))
-                                {
-                                    fieldDictionary[key] = value;
-                                }
-                                else
-                                {
-                                    fieldDictionary.Add(key, value);
-                                }
+                                fieldDictionary[key] = value;
                             }
                         }
                     }
@@ -592,15 +582,7 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                             if (value != null)
                             {
                                 var key = SafeFieldId(indexPad);
-
-                                if (fieldDictionary.ContainsKey(key))
-                                {
-                                    fieldDictionary[key] = value;
-                                }
-                                else
-                                {
-                                    fieldDictionary.Add(key, value);
-                                }
+                                fieldDictionary[key] = value;
                             }
                         }
                     }
@@ -640,15 +622,7 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                             if (value != null)
                             {
                                 var key = SafeFieldId(fieldId);
-
-                                if (fieldDictionary.ContainsKey(key))
-                                {
-                                    fieldDictionary[key] = value;
-                                }
-                                else
-                                {
-                                    fieldDictionary.Add(key, value);
-                                }
+                                fieldDictionary[key] = value;
                             }
                         }
                     }
@@ -706,15 +680,7 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                             if (value != null)
                             {
                                 var key = SafeFieldId(fieldId);
-
-                                if (fieldDictionary.ContainsKey(key))
-                                {
-                                    fieldDictionary[key] = value;
-                                }
-                                else
-                                {
-                                    fieldDictionary.Add(key, value);
-                                }
+                                fieldDictionary[key] = value;
                             }
                         }
                     }

--- a/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
@@ -511,7 +511,7 @@ namespace GuaranteedRate.Sextant.EncompassUtils
             var loanNumber = currentLoan.LoanNumber;
             try
             {
-                foreach (string fieldId in fieldIds)
+                foreach (var fieldId in fieldIds)
                 {
                     int index = 0;
                     try
@@ -614,17 +614,10 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                 {
                     try
                     {
-                        if (!currentLoan.Fields[fieldId].IsEmpty())
-                        {
-                            var fieldObject = currentLoan.Fields[fieldId].Value;
-                            string value = ParseField(fieldObject);
-
-                            if (value != null)
-                            {
-                                var key = SafeFieldId(fieldId);
-                                fieldDictionary[key] = value;
-                            }
-                        }
+                        var fieldObject = currentLoan.Fields[fieldId].Value;
+                        string value = ParseField(fieldObject);
+                        var key = SafeFieldId(fieldId);
+                        fieldDictionary[key] = value;
                     }
                     catch (Exception e)
                     {
@@ -654,7 +647,7 @@ namespace GuaranteedRate.Sextant.EncompassUtils
             catch (Exception e)
             {
                 Loggly.Error("LoandataUtils",
-                    "Failed to pull loan=" + loanNumber + " field=" + field + " Exception: " + e);
+                    $"Failed to pull loan={loanNumber} field={field} Exception: {e}");
             }
             return null;
         }
@@ -664,10 +657,9 @@ namespace GuaranteedRate.Sextant.EncompassUtils
         {
             if (fieldIds == null || fieldIds.Count == 0) return fieldDictionary;
 
-            string loanNumber = null;
             try
             {
-                loanNumber = currentLoan.LoanNumber;
+                var loanNumber = currentLoan.LoanNumber;
                 foreach (var fieldId in fieldIds)
                 {
                     try

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.1.0.0")]
-[assembly: AssemblyFileVersion("17.1.0.0")]
+[assembly: AssemblyVersion("17.1.0.1")]
+[assembly: AssemblyFileVersion("17.1.0.1")]


### PR DESCRIPTION
-trimming field ids prior to lookup
-checking if a key exists in a dictionary before pushing to it or overwriting it