### PR TITLE
add IJsonEncompassConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
++## v17.1.0.3 / 2017 Mar 07
+> Extending JsonEncompassConfig to implement an IJsonEncompassConfig
+
 ## v17.1.0.1 / 2017 Feb 23
 > This release forces trimming on field ids to prevent Encompass "Field ID not found" errors 
 

--- a/GuaranteedRate.Sextant/Config/IJsonEncompassConfig.cs
+++ b/GuaranteedRate.Sextant/Config/IJsonEncompassConfig.cs
@@ -1,0 +1,7 @@
+﻿
+namespace GuaranteedRate.Sextant.Config
+{
+    public interface IJsonEncompassConfig : IEncompassConfig
+    {
+    }
+}

--- a/GuaranteedRate.Sextant/Config/JsonEncompassConfig.cs
+++ b/GuaranteedRate.Sextant/Config/JsonEncompassConfig.cs
@@ -12,7 +12,7 @@ namespace GuaranteedRate.Sextant.Config
     /// <summary>
     /// provides a simple config fild parser for JSON files.  Defaults to ASCII encoding
     /// </summary>
-    public class JsonEncompassConfig : IEncompassConfig
+    public class JsonEncompassConfig : IJsonEncompassConfig
     {
         private JObject _jsonObject = null;
         private Encoding _encoding = Encoding.ASCII;

--- a/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
+++ b/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
@@ -156,6 +156,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Config\IEncompassConfig.cs" />
+    <Compile Include="Config\IJsonEncompassConfig.cs" />
     <Compile Include="Config\IniConfig.cs" />
     <Compile Include="Config\JsonEncompassConfig.cs" />
     <Compile Include="EncompassUtils\EncompassInit.cs" />


### PR DESCRIPTION
IJsonEncompassConfig is needed if you want to ensure that the consuming class is being passed a JsonEncompassConfig.