### PR TITLE
support T GetValue<T>(string key, T defaultValue = default(T))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v17.1.0.4 / 2017 Mar 16
-> This release extends IJsonEncompassConfig to support T T GetValue<T>(string key, T defaultValue = default(T))
+> This release extends IJsonEncompassConfig to support T GetValue<T>(string key, T defaultValue = default(T))
 
 ```c#
 [GuaranteedRate.Sextant "17.1.0.4"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v17.1.0.4 / 2017 Mar 16
+> This release extends IJsonEncompassConfig to support T T GetValue<T>(string key, T defaultValue = default(T))
+
+```c#
+[GuaranteedRate.Sextant "17.1.0.4"]
+```
+
 ## v17.1.0.3 / 2017 Mar 07
 > Extending JsonEncompassConfig to implement an IJsonEncompassConfig
 

--- a/GuaranteedRate.Sextant/Config/IJsonEncompassConfig.cs
+++ b/GuaranteedRate.Sextant/Config/IJsonEncompassConfig.cs
@@ -3,5 +3,6 @@ namespace GuaranteedRate.Sextant.Config
 {
     public interface IJsonEncompassConfig : IEncompassConfig
     {
+        T GetValue<T>(string key, T defaultValue = default(T));
     }
 }

--- a/GuaranteedRate.Sextant/Config/JsonEncompassConfig.cs
+++ b/GuaranteedRate.Sextant/Config/JsonEncompassConfig.cs
@@ -73,6 +73,22 @@ namespace GuaranteedRate.Sextant.Config
             return val.ToString();
         }
 
+        public T GetValue<T>(string key, T defaultValue = default(T))
+        {
+            var token = _jsonObject.SelectToken(key);
+
+            if (token == null)
+            {
+                if (!EqualityComparer<T>.Default.Equals(defaultValue, default(T)))
+                {
+                    return defaultValue;
+                }
+
+                return default(T);
+            }
+
+            return token.ToObject<T>();
+        }
 
         /// <summary>
         /// Initializes the config from a default "sextant.json" file.

--- a/GuaranteedRate.Sextant/Config/JsonEncompassConfig.cs
+++ b/GuaranteedRate.Sextant/Config/JsonEncompassConfig.cs
@@ -73,18 +73,24 @@ namespace GuaranteedRate.Sextant.Config
             return val.ToString();
         }
 
+        /// <summary>
+        /// This takes a type of T, a key and an optional default value.
+        /// If the json value assigned to the key is an empty string it 
+        /// will return a null object or an empty string depending on the 
+        /// type of T
+        /// </summary>
+        /// <typeparam name="T">Object type to be returned</typeparam>
+        /// <param name="key">Full path to the key(e.g. "Shape.Square.Color")</param>
+        /// <param name="defaultValue">The value to be returned if the requested value is not found</param>
+        /// <returns>A value of the requested type</returns>
         public T GetValue<T>(string key, T defaultValue = default(T))
         {
             var token = _jsonObject.SelectToken(key);
 
-            if (token == null)
+            if (token == null ||
+                (token.Type == JTokenType.String && !token.HasValues))
             {
-                if (!EqualityComparer<T>.Default.Equals(defaultValue, default(T)))
-                {
-                    return defaultValue;
-                }
-
-                return default(T);
+                return defaultValue;
             }
 
             return token.ToObject<T>();

--- a/GuaranteedRate.SextantTests/Config/JsonEncompassConfigTests.cs
+++ b/GuaranteedRate.SextantTests/Config/JsonEncompassConfigTests.cs
@@ -22,7 +22,7 @@ namespace GuaranteedRate.Sextant.Config.Tests
         [Test]
         public void ForValidConfigReturnGoodValues()
         {
-            Assert.That(_sut.GetKeys().Count == 30, $"Expected 30, got {_sut.GetKeys().Count}");
+            Assert.That(_sut.GetKeys().Count == 31, $"Expected 31, got {_sut.GetKeys().Count}");
             Assert.That(_sut.GetValue("widget.debug", false).Equals(true), $"Expected 'true' , got '{_sut.GetValue("widget.debug", false)}'");
             Assert.That(_sut.GetValue("widget.window.title").Equals("Sample Konfabulator Widget"));
 
@@ -87,6 +87,30 @@ namespace GuaranteedRate.Sextant.Config.Tests
 
             Assert.IsNotNull(actual);
             Assert.AreEqual(0, actual.Count);
+        }
+
+        [Test]
+        public void GivenEmptyStringArray_WhenGetValueTArray_ThenReturnsEmptyArray()
+        {
+            var actual = _sut.GetValue<WindowModel[]>("widget.emptyStringWindowList");
+
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        public void GivenEmptyStringArray_WhenGetValueTList_ThenReturnsEmptyList()
+        {
+            var actual = _sut.GetValue<List<WindowModel>>("widget.emptyStringWindowList");
+
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        public void GivenEmptyStringArray_WhenGetValueTIList_ThenReturnsEmptyIList()
+        {
+            var actual = _sut.GetValue<IList<WindowModel>>("widget.emptyStringWindowList");
+
+            Assert.IsNull(actual);
         }
 
         [Test]

--- a/GuaranteedRate.SextantTests/Config/JsonEncompassConfigTests.cs
+++ b/GuaranteedRate.SextantTests/Config/JsonEncompassConfigTests.cs
@@ -21,7 +21,7 @@ namespace GuaranteedRate.Sextant.Config.Tests
         [Test]
         public void ForValidConfigReturnGoodValues()
         {
-            Assert.That(_sut.GetKeys().Count == 22, $"Expected 22, got {_sut.GetKeys().Count}");
+            Assert.That(_sut.GetKeys().Count == 28, $"Expected 28, got {_sut.GetKeys().Count}");
             Assert.That(_sut.GetValue("widget.debug", false).Equals(true), $"Expected 'true' , got '{_sut.GetValue("widget.debug", false)}'");
             Assert.That(_sut.GetValue("widget.window.title").Equals("Sample Konfabulator Widget"));
 

--- a/GuaranteedRate.SextantTests/Config/JsonEncompassConfigTests.cs
+++ b/GuaranteedRate.SextantTests/Config/JsonEncompassConfigTests.cs
@@ -1,29 +1,56 @@
 ﻿using System;
+using System.IO;
+using GuaranteedRate.SextantTests.Config;
 using NUnit.Framework;
 
 namespace GuaranteedRate.Sextant.Config.Tests
 {
-    [TestFixture()]
+    [TestFixture]
     public class JsonEncompassConfigTests
     {
-        private string _json = "        {       \"widget\": {    \"debug\": \"true\",    \"window\": {        \"title\": \"Sample Konfabulator Widget\",        \"name\": \"main_window\",        \"width\": 500,        \"height\": 500    },    \"image\": {         \"src\": \"Images/Sun.png\",        \"name\": \"sun1\",        \"hOffset\": 250,        \"vOffset\": 250,        \"alignment\": \"center\"    },    \"text\": {        \"data\": \"Click Here\",        \"size\": 36,        \"style\": \"bold\",        \"name\": \"text1\",        \"hOffset\": 250,        \"vOffset\": 100,        \"alignment\": \"center\",        \"onMouseUp\": \"sun1.opacity = (sun1.opacity / 100) * 90;\"    }}}    ";
+        private JsonEncompassConfig _sut;
 
-        [Test()]
-        public void ForValidConfigReturnGoodValues()
+        [SetUp]
+        public void SetUp()
         {
-            var config = new JsonEncompassConfig();
-                config.Init(_json);
-            Assert.That(config.GetKeys().Count == 22, String.Format("Expected 22, got {0}", config.GetKeys().Count));
-            Assert.That(config.GetValue("widget.debug", false).Equals(true),
-                String.Format("Expected 'true' , got '{0}'", config.GetValue("widget.debug", false)));
-            Assert.That(config.GetValue("widget.window.title").Equals("Sample Konfabulator Widget"));
-
-            var subConfig = config.GetConfigGroup("widget.window");
-            Assert.That(subConfig.GetValue("title").Equals("Sample Konfabulator Widget"));
-
+            _sut = new JsonEncompassConfig();
+            _sut.Init(File.ReadAllText("Config\\TestJson.json"));
         }
 
+        [Test]
+        public void ForValidConfigReturnGoodValues()
+        {
+            Assert.That(_sut.GetKeys().Count == 22, $"Expected 22, got {_sut.GetKeys().Count}");
+            Assert.That(_sut.GetValue("widget.debug", false).Equals(true), $"Expected 'true' , got '{_sut.GetValue("widget.debug", false)}'");
+            Assert.That(_sut.GetValue("widget.window.title").Equals("Sample Konfabulator Widget"));
 
+            var subConfig = _sut.GetConfigGroup("widget.window");
+            Assert.That(subConfig.GetValue("title").Equals("Sample Konfabulator Widget"));
+        }
 
+        [Test]
+        public void WhenGetValueT_ThenValueTReturned()
+        {
+            var model = _sut.GetValue<WindowModel>("widget.window");
+
+            Assert.IsNotNull(model);
+        }
+
+        [Test]
+        public void GivenInvalidPath_WhenGetValueT_ThenReturnDefault()
+        {
+            var model = _sut.GetValue<WindowModel>("widgets.window");
+
+            Assert.IsNull(model);
+        }
+
+        [Test]
+        public void GivenInvalidPathWithDefaultReturnVal_WhenGetValueT_ThenReturnDefaultReturnVal()
+        {
+            var expected = new WindowModel {Height = 1, Name = "test", Title = "test title", Width = 1};
+            var actual = _sut.GetValue<WindowModel>("widgets.window", expected);
+
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/GuaranteedRate.SextantTests/Config/JsonEncompassConfigTests.cs
+++ b/GuaranteedRate.SextantTests/Config/JsonEncompassConfigTests.cs
@@ -79,6 +79,24 @@ namespace GuaranteedRate.Sextant.Config.Tests
             Assert.AreEqual(1, model.Length);
         }
 
+
+        [Test]
+        public void WhenGetValueTIList_ThenReturnTIList()
+        {
+            var model = _sut.GetValue<IList<WindowModel>>("widget.windowList");
+
+            Assert.IsNotNull(model);
+            Assert.AreEqual(1, model.Count);
+        }
+
+        [Test]
+        public void GivenInvalidPath_WhenGetValueTIList_ThenReturnDefault()
+        {
+            var model = _sut.GetValue<IList<WindowModel>>("badPath.windowList");
+
+            Assert.IsNull(model);
+        }
+
         [Test]
         public void GivenInvalidPathWithDefaultReturnVal_WhenGetValueT_ThenReturnDefaultReturnVal()
         {

--- a/GuaranteedRate.SextantTests/Config/JsonEncompassConfigTests.cs
+++ b/GuaranteedRate.SextantTests/Config/JsonEncompassConfigTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using GuaranteedRate.SextantTests.Config;
 using NUnit.Framework;
 
@@ -21,7 +22,7 @@ namespace GuaranteedRate.Sextant.Config.Tests
         [Test]
         public void ForValidConfigReturnGoodValues()
         {
-            Assert.That(_sut.GetKeys().Count == 28, $"Expected 28, got {_sut.GetKeys().Count}");
+            Assert.That(_sut.GetKeys().Count == 30, $"Expected 30, got {_sut.GetKeys().Count}");
             Assert.That(_sut.GetValue("widget.debug", false).Equals(true), $"Expected 'true' , got '{_sut.GetValue("widget.debug", false)}'");
             Assert.That(_sut.GetValue("widget.window.title").Equals("Sample Konfabulator Widget"));
 
@@ -59,6 +60,57 @@ namespace GuaranteedRate.Sextant.Config.Tests
             var model = _sut.GetValue<WindowModel[]>("badPath.window");
 
             Assert.IsNull(model);
+        }
+
+        [Test]
+        public void GivenEmptyArray_WhenGetValueTArray_ThenReturnsEmptyArray()
+        {
+            var actual = _sut.GetValue<WindowModel[]>("widget.emptyWindowList");
+
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(0, actual.Length);
+        }
+
+        [Test]
+        public void GivenEmptyArray_WhenGetValueTList_ThenReturnsEmptyList()
+        {
+            var actual = _sut.GetValue<List<WindowModel>>("widget.emptyWindowList");
+
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(0, actual.Count);
+        }
+
+        [Test]
+        public void GivenEmptyArray_WhenGetValueTIList_ThenReturnsEmptyIList()
+        {
+            var actual = _sut.GetValue<IList<WindowModel>>("widget.emptyWindowList");
+
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(0, actual.Count);
+        }
+
+        [Test]
+        public void GivenNullArray_WhenGetValueTArray_ThenReturnsNull()
+        {
+            var actual = _sut.GetValue<WindowModel[]>("widget.nullWindowList");
+
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        public void GivenNullArray_WhenGetValueTList_ThenReturnsNull()
+        {
+            var actual = _sut.GetValue<List<WindowModel>>("widget.nullWindowList");
+
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        public void GivenNullArray_WhenGetValueTIList_ThenReturnsNull()
+        {
+            var actual = _sut.GetValue<IList<WindowModel>>("widget.nullWindowList");
+
+            Assert.IsNull(actual);
         }
 
         [Test]

--- a/GuaranteedRate.SextantTests/Config/JsonEncompassConfigTests.cs
+++ b/GuaranteedRate.SextantTests/Config/JsonEncompassConfigTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using GuaranteedRate.SextantTests.Config;
 using NUnit.Framework;
@@ -39,9 +40,43 @@ namespace GuaranteedRate.Sextant.Config.Tests
         [Test]
         public void GivenInvalidPath_WhenGetValueT_ThenReturnDefault()
         {
-            var model = _sut.GetValue<WindowModel>("widgets.window");
+            var model = _sut.GetValue<WindowModel>("badPath.window");
 
             Assert.IsNull(model);
+        }
+
+        [Test]
+        public void GivenInvalidPath_WhenGetValueTList_ThenReturnDefault()
+        {
+            var model = _sut.GetValue<List<WindowModel>>("badPath.window");
+
+            Assert.IsNull(model);
+        }
+
+        [Test]
+        public void GivenInvalidPath_WhenGetValueTArray_ThenReturnDefault()
+        {
+            var model = _sut.GetValue<WindowModel[]>("badPath.window");
+
+            Assert.IsNull(model);
+        }
+
+        [Test]
+        public void WhenGetValueTList_ThenReturnList()
+        {
+            var model = _sut.GetValue<List<WindowModel>>("widget.windowList");
+
+            Assert.IsNotNull(model);
+            Assert.AreEqual(1, model.Count);
+        }
+
+        [Test]
+        public void WhenGetValueTArray_ThenReturnArray()
+        {
+            var model = _sut.GetValue<WindowModel[]>("widget.windowList");
+
+            Assert.IsNotNull(model);
+            Assert.AreEqual(1, model.Length);
         }
 
         [Test]

--- a/GuaranteedRate.SextantTests/Config/TestJson.json
+++ b/GuaranteedRate.SextantTests/Config/TestJson.json
@@ -2,7 +2,8 @@
   "widget": {
     "debug": "true",
     "emptyWindowList": [ ],
-    "nullWindowList":  null,
+    "nullWindowList": null,
+    "emptyStringWindowList": "",
     "image": {
       "alignment": "center",
       "hOffset": 250,

--- a/GuaranteedRate.SextantTests/Config/TestJson.json
+++ b/GuaranteedRate.SextantTests/Config/TestJson.json
@@ -1,0 +1,28 @@
+﻿{
+  "widget": {
+    "debug": "true",
+    "image": {
+      "alignment": "center",
+      "hOffset": 250,
+      "name": "sun1",
+      "src": "Images/Sun.png",
+      "vOffset": 250
+    },
+    "text": {
+      "alignment": "center",
+      "data": "Click Here",
+      "hOffset": 250,
+      "name": "text1",
+      "onMouseUp": "sun1.opacity = (sun1.opacity / 100) * 90;",
+      "size": 36,
+      "style": "bold",
+      "vOffset": 100
+    },
+    "window": {
+      "height": 500,
+      "name": "main_window",
+      "title": "Sample Konfabulator Widget",
+      "width": 500
+    }
+  }
+}

--- a/GuaranteedRate.SextantTests/Config/TestJson.json
+++ b/GuaranteedRate.SextantTests/Config/TestJson.json
@@ -1,6 +1,8 @@
 ﻿{
   "widget": {
     "debug": "true",
+    "emptyWindowList": [ ],
+    "nullWindowList":  null,
     "image": {
       "alignment": "center",
       "hOffset": 250,

--- a/GuaranteedRate.SextantTests/Config/TestJson.json
+++ b/GuaranteedRate.SextantTests/Config/TestJson.json
@@ -23,6 +23,14 @@
       "name": "main_window",
       "title": "Sample Konfabulator Widget",
       "width": 500
-    }
+    },
+    "windowList": [
+      {
+        "height": 500,
+        "name": "main_window",
+        "title": "Sample Konfabulator Widget",
+        "width": 500
+      }
+    ]
   }
 }

--- a/GuaranteedRate.SextantTests/Config/WindowModel.cs
+++ b/GuaranteedRate.SextantTests/Config/WindowModel.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace GuaranteedRate.SextantTests.Config
+{
+    public class WindowModel
+    {
+        [JsonProperty("height")]
+        public int Height { get; set; } 
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("width")]
+        public int Width { get; set; }
+    }
+}

--- a/GuaranteedRate.SextantTests/GuaranteedRate.SextantTests.csproj
+++ b/GuaranteedRate.SextantTests/GuaranteedRate.SextantTests.csproj
@@ -127,6 +127,9 @@
       <HintPath>..\packages\EncompassSDK.Complete.17.1.0.0\lib\net45\Jed.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
@@ -164,9 +167,13 @@
   <ItemGroup>
     <Compile Include="Config\IniConfigTests.cs" />
     <Compile Include="Config\JsonEncompassConfigTests.cs" />
+    <Compile Include="Config\WindowModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Config\TestJson.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/GuaranteedRate.SextantTests/packages.config
+++ b/GuaranteedRate.SextantTests/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="EncompassSDK.Complete" version="17.1.0.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This will allow for embedding entire object graphs in a JSON config.  Most notably, this will do away with the need to hack array values into a pipe delimited string.