### PR TITLE
Adding back defensive if braces to prevent null value set by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v17.1.0.5 / 2017 Mar 20
+> This release corrects a regression in LoanDataUtils that allowed null values to be set to properties instead of leaving unset properties as empty strings.
+
+```c#
+[GuaranteedRate.Sextant "17.1.0.5"]
+```
+
 ## v17.1.0.4 / 2017 Mar 16
 > This release extends IJsonEncompassConfig to support T GetValue<T>(string key, T defaultValue = default(T))
 

--- a/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/LoanDataUtils.cs
@@ -484,8 +484,11 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                         string val = ExtractSimpleField(currentLoan, fullKey);
                         try
                         {
-                            var insertKey = SafeFieldId(fullKey);
-                            fieldDictionary[insertKey] = val;
+                            if (val != null)
+                            {
+                                var insertKey = SafeFieldId(fullKey);
+                                fieldDictionary[insertKey] = val;
+                            }
                         }
                         catch (Exception ex)
                         {
@@ -508,9 +511,9 @@ namespace GuaranteedRate.Sextant.EncompassUtils
         {
             if (fieldIds == null || fieldIds.Count == 0) return fieldDictionary;
 
-            var loanNumber = currentLoan.LoanNumber;
             try
             {
+                var loanNumber = currentLoan.LoanNumber;
                 foreach (var fieldId in fieldIds)
                 {
                     int index = 0;
@@ -616,8 +619,11 @@ namespace GuaranteedRate.Sextant.EncompassUtils
                     {
                         var fieldObject = currentLoan.Fields[fieldId].Value;
                         string value = ParseField(fieldObject);
-                        var key = SafeFieldId(fieldId);
-                        fieldDictionary[key] = value;
+                        if (value != null)
+                        {
+                            var key = SafeFieldId(fieldId);
+                            fieldDictionary[key] = value;
+                        }
                     }
                     catch (Exception e)
                     {

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.1.0.3")]
-[assembly: AssemblyFileVersion("17.1.0.3")]
+[assembly: AssemblyVersion("17.1.0.5")]
+[assembly: AssemblyFileVersion("17.1.0.5")]


### PR DESCRIPTION
UPDATE: All fields are initially pulled in and set to an empty string value.  When the defensive ifs were removed null values were set over the default empty string.

***line 487***
I want to dive into why these if blocks were removed.  @jeffpsherman recommended removal and I believe it was due to not needing a check because of upstream filtering, but I want to confirm.

related commit : 
https://github.com/Guaranteed-Rate/GuaranteedRate.Sextant/commit/543d07fc13a805eb204a1e06b7634f1e050867f6

-------------

***line 619***
I assume this if block was removed for the same reason however my commit comment at the time was not ideal.

related commit:
https://github.com/Guaranteed-Rate/GuaranteedRate.Sextant/commit/fdc70ece01759a1fa856c1f98cc6b9c5e00ef2f