### PR TITLE
Armoring Loan OpenLoan(Session session, string guid)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v17.2.0.4 / 2017 Apr 21
+> Encompass expects string interpretations of Guids to be wrapped in braces.  Safe checking for this as Guid.ToString() will emit a guid that does not follow this standard.
+
 ## v17.2.0.3 / 2017 Apr 17
 > This release upgrades Newtonsoft to 10.0.2 which is needed by Encompass 17.2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v17.2.0.5 / 2017 Apr 21
+> Have SessionUtils support Loan OpenLoan(Session session, Guid guid)
+
 ## v17.2.0.4 / 2017 Apr 21
 > Encompass expects string interpretations of Guids to be wrapped in braces.  Safe checking for this as Guid.ToString() will emit a guid that does not follow this standard.
 

--- a/GuaranteedRate.Sextant/EncompassUtils/SessionUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/SessionUtils.cs
@@ -36,7 +36,7 @@ namespace GuaranteedRate.Sextant.EncompassUtils
 
         public static Loan OpenLoan(Session session, Guid guid)
         {
-            return OpenLoan(session, guid);
+            return OpenLoan(session, guid.ToString());
         }
 
         /// <summary>

--- a/GuaranteedRate.Sextant/EncompassUtils/SessionUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/SessionUtils.cs
@@ -25,6 +25,16 @@ namespace GuaranteedRate.Sextant.EncompassUtils
 
         public static Loan OpenLoan(Session session, string guid)
         {
+            if (!guid.StartsWith("{"))
+            {
+                guid = "{" + guid;
+            }
+
+            if (!guid.EndsWith("}"))
+            {
+                guid = guid + "}";
+            }
+
             return session.Loans.Open(guid);
         }
 

--- a/GuaranteedRate.Sextant/EncompassUtils/SessionUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/SessionUtils.cs
@@ -3,10 +3,6 @@ using EllieMae.Encompass.Client;
 using EllieMae.Encompass.Collections;
 using EllieMae.Encompass.Query;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GuaranteedRate.Sextant.EncompassUtils
 {
@@ -36,6 +32,11 @@ namespace GuaranteedRate.Sextant.EncompassUtils
             }
 
             return session.Loans.Open(guid);
+        }
+
+        public static Loan OpenLoan(Session session, Guid guid)
+        {
+            return OpenLoan(session, guid);
         }
 
         /// <summary>

--- a/GuaranteedRate.Sextant/EncompassUtils/SessionUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/SessionUtils.cs
@@ -36,7 +36,7 @@ namespace GuaranteedRate.Sextant.EncompassUtils
 
         public static Loan OpenLoan(Session session, Guid guid)
         {
-            return OpenLoan(session, guid.ToString());
+            return OpenLoan(session, guid.ToString("B"));
         }
 
         /// <summary>

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.0.4")]
-[assembly: AssemblyFileVersion("17.2.0.4")]
+[assembly: AssemblyVersion("17.2.0.5")]
+[assembly: AssemblyFileVersion("17.2.0.5")]

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.0.3")]
-[assembly: AssemblyFileVersion("17.2.0.3")]
+[assembly: AssemblyVersion("17.2.0.4")]
+[assembly: AssemblyFileVersion("17.2.0.4")]


### PR DESCRIPTION
Encompass expects string interpretations of Guids to be wrapped in braces.  Safe checking for this as Guid.ToString() will emit a guid that does not follow this standard.