### PR TITLE
Add StatsD metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v17.2.2.0 / 2017 JUl 26
+> This release intruduces the concept of StatsD driven metrics tracking.  We are leveraging [Metrics.NET](https://github.com/Recognos/Metrics.NET)
+to backbone the effort of transposing metrics into StatsD compliant metrics for consumption by our third party reporters.  
+We have elected to supoort Graphite with the `GraphiteReporter` from [Metrics.NET.Graphite](https://github.com/Recognos/Metrics.NET.Graphite) and
+Datadog with the `DatadogReporter` from  [Metrics.NET.Datadog](https://github.com/danzel/Metrics.NET.Datadog)
+* **Add** - `SimpleMetrics` and `StatsDMetrics` as available Metrics trackers
+
+```csharp
+[GuaranteedRate.Sextant "17.2.2.0"]
+```
+
 ## v17.2.1.0 / 2017 Jul 13
 > This release intruduces a new approach to logging and metrics tracking.  Instead of instantiating a Loggly logger you can now use the all 
 purpose `Logger` object and attach an appender (such as `LogglyAppender` and `ElasticsearchLogAppender`) to log system data.  Following suit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ to backbone the effort of transposing metrics into StatsD compliant metrics for 
 We have elected to supoort Graphite with the `GraphiteReporter` from [Metrics.NET.Graphite](https://github.com/Recognos/Metrics.NET.Graphite) and
 Datadog with the `DatadogReporter` from  [Metrics.NET.Datadog](https://github.com/danzel/Metrics.NET.Datadog)
 * **Add** - `SimpleMetrics` and `StatsDMetrics` as available Metrics trackers
+* **Update** - Sextant has been rolled up to .NET 4.5.2 to utilize Metrics.NET 
 
 ```csharp
 [GuaranteedRate.Sextant "17.2.2.0"]

--- a/GuaranteedRate.Examples.FieldUtils/GuaranteedRate.Examples.FieldUtils.csproj
+++ b/GuaranteedRate.Examples.FieldUtils/GuaranteedRate.Examples.FieldUtils.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GuaranteedRate.Examples.FieldUtils</RootNamespace>
     <AssemblyName>GuaranteedRate.Examples.FieldUtils</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -173,7 +173,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/GuaranteedRate.Examples.FieldUtils/app.config
+++ b/GuaranteedRate.Examples.FieldUtils/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/GuaranteedRate.Examples.FieldUtils/packages.config
+++ b/GuaranteedRate.Examples.FieldUtils/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net45" />
+  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net452" />
 </packages>

--- a/GuaranteedRate.Examples.LoanDataUtils/GuaranteedRate.Examples.LoanDataUtils.csproj
+++ b/GuaranteedRate.Examples.LoanDataUtils/GuaranteedRate.Examples.LoanDataUtils.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GuaranteedRate.Examples.LoanDataUtils</RootNamespace>
     <AssemblyName>GuaranteedRate.Examples.LoanDataUtils</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -167,7 +167,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/GuaranteedRate.Examples.LoanDataUtils/app.config
+++ b/GuaranteedRate.Examples.LoanDataUtils/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/GuaranteedRate.Examples.LoanDataUtils/packages.config
+++ b/GuaranteedRate.Examples.LoanDataUtils/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
 </packages>

--- a/GuaranteedRate.Examples.ReportingUtils/GuaranteedRate.Examples.ReportingUtils.csproj
+++ b/GuaranteedRate.Examples.ReportingUtils/GuaranteedRate.Examples.ReportingUtils.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GuaranteedRate.Examples.ReportingUtils</RootNamespace>
     <AssemblyName>GuaranteedRate.Examples.ReportingUtils</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/GuaranteedRate.Examples.ReportingUtils/app.config
+++ b/GuaranteedRate.Examples.ReportingUtils/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/GuaranteedRate.Examples.ReportingUtils/packages.config
+++ b/GuaranteedRate.Examples.ReportingUtils/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net45" />
+  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net452" />
 </packages>

--- a/GuaranteedRate.Examples.UserUtils/App.config
+++ b/GuaranteedRate.Examples.UserUtils/App.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/GuaranteedRate.Examples.UserUtils/GuaranteedRate.Examples.UserUtils.csproj
+++ b/GuaranteedRate.Examples.UserUtils/GuaranteedRate.Examples.UserUtils.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GuaranteedRate.Examples.UserUtils</RootNamespace>
     <AssemblyName>GuaranteedRate.Examples.UserUtils</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -168,7 +168,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/GuaranteedRate.Examples.UserUtils/packages.config
+++ b/GuaranteedRate.Examples.UserUtils/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net45" />
+  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net452" />
 </packages>

--- a/GuaranteedRate.Sextant.Integration.Tests/app.config
+++ b/GuaranteedRate.Sextant.Integration.Tests/app.config
@@ -27,7 +27,8 @@
     <add key="LogglyLogAppender.Tags" value="dev,project1" />
     
     <!-- Metrics -->
-    <add key="GraphiteReporter.Host" value="https://my.graphite.com" />
+    <add key="GraphiteReporter.Enabled" value="true" />
+    <add key="GraphiteReporter.Host" value="my.graphite.com" />
     <add key="GraphiteReporter.Port" value="1000" />
     <add key="GraphiteReporter.QueueSize" value="1000" />
     <add key="GraphiteReporter.RetryLimit" value="3" />
@@ -38,6 +39,7 @@
     <add key="DatadogReporter.ApiKey" value="my-api-key" />
     <add key="DatadogReporter.QueueSize" value="1000" />
     <add key="DatadogReporter.RetryLimit" value="3" />
+    <add key="DatadogReporter.RootNamespace" value="encompass" />
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/GuaranteedRate.Sextant.Tests/GuaranteedRate.Sextant.Tests.csproj
+++ b/GuaranteedRate.Sextant.Tests/GuaranteedRate.Sextant.Tests.csproj
@@ -34,6 +34,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Client, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
       <HintPath>..\packages\EncompassSDK.Complete.17.2.0.2\lib\net45\Client.dll</HintPath>

--- a/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
+++ b/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GuaranteedRate.Sextant</RootNamespace>
     <AssemblyName>GuaranteedRate.Sextant</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -127,6 +127,18 @@
       <HintPath>..\packages\EncompassSDK.Complete.17.2.0.2\lib\net45\Jed.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Metrics, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Metrics.NET.0.5.0-pre\lib\net45\Metrics.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Metrics.NET.Datadog, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Metrics.NET.Datadog.1.0.0\lib\net452\Metrics.NET.Datadog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Metrics.NET.Graphite, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Metrics.NET.Graphite.0.5.0-pre\lib\net45\Metrics.NET.Graphite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Nest, Version=5.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
       <HintPath>..\packages\NEST.5.4.0\lib\net45\Nest.dll</HintPath>
       <Private>True</Private>
@@ -184,7 +196,9 @@
     <Compile Include="EncompassUtils\SessionUtils.cs" />
     <Compile Include="EncompassUtils\UserUtils.cs" />
     <Compile Include="Metrics\Graphite\GraphiteReporter.cs" />
+    <Compile Include="Metrics\Graphite\StatsDGraphiteReport.cs" />
     <Compile Include="Metrics\IReporter.cs" />
+    <Compile Include="Metrics\StatsDMetrics.cs" />
     <Compile Include="WebClients\ApiException.cs" />
     <Compile Include="WebClients\AsyncEventReporter.cs" />
     <Compile Include="Logging\ConsoleLogAppender.cs" />
@@ -195,13 +209,15 @@
     <Compile Include="Logging\Loggly\LogglyLogAppender.cs" />
     <Compile Include="WebClients\SecureAsyncEventReporter.cs" />
     <Compile Include="Metrics\Datadog\DatadogReporter.cs" />
-    <Compile Include="Metrics\Metrics.cs" />
+    <Compile Include="Metrics\SimpleMetrics.cs" />
     <Compile Include="Models\EncompassUser.cs" />
     <Compile Include="Models\MachineUser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="GuaranteedRate.Sextant.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/GuaranteedRate.Sextant/Metrics/Graphite/StatsDGraphiteReport.cs
+++ b/GuaranteedRate.Sextant/Metrics/Graphite/StatsDGraphiteReport.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Metrics.Graphite;
+
+namespace GuaranteedRate.Sextant.Metrics.Graphite
+{
+    public class StatsDGraphiteReport : GraphiteReport
+    {
+        private string _rootNamespace;
+
+        public StatsDGraphiteReport(GraphiteSender sender, string rootNamespace) : base(sender)
+        {
+            _rootNamespace = rootNamespace;
+        }
+
+        protected override void Send(string name, string value)
+        {
+            var sendName = string.IsNullOrEmpty(_rootNamespace)
+                ? name
+                : $"{_rootNamespace}.{name}";
+
+            base.Send(sendName, value);
+        }
+    }
+}

--- a/GuaranteedRate.Sextant/Metrics/SimpleMetrics.cs
+++ b/GuaranteedRate.Sextant/Metrics/SimpleMetrics.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace GuaranteedRate.Sextant.Metrics
 {
-    public class Metrics
+    public class SimpleMetrics
     {
         private static volatile IList<IReporter> _reporters = new List<IReporter>();
         private static readonly object syncRoot = new Object();

--- a/GuaranteedRate.Sextant/Metrics/StatsDMetrics.cs
+++ b/GuaranteedRate.Sextant/Metrics/StatsDMetrics.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GuaranteedRate.Sextant.Config;
+using GuaranteedRate.Sextant.Metrics.Graphite;
+using Metrics;
+using Metrics.Graphite;
+using Metrics.NET.Datadog;
+
+namespace GuaranteedRate.Sextant.Metrics
+{
+    public class StatsDMetrics
+    {
+        #region Config Mappings
+
+        private static string DATADOG_ENABLED = "DatadogReporter.Enabled";
+        private static string DATADOG_APIKEY = "DatadogReporter.ApiKey";
+        private static string DATADOG_ROOTNAMESPACE = "DatadogReporter.RootNamespace";
+
+        private static string GRAPHITE_ENABLED = "GraphiteReporter.Enabled";
+        private static string GRAPHITE_HOST = "GraphiteReporter.Host";
+        private static string GRAPHITE_PORT = "GraphiteReporter.Port";
+        private static string GRAPHITE_ROOTNAMESPACE = "GraphiteReporter.RootNamespace";
+
+        #endregion
+
+        public static void Setup(IEncompassConfig config)
+        {
+            var metricConfig = Metric.Config;
+
+            var datadogEnabled = config.GetValue(DATADOG_ENABLED, false);
+            if (datadogEnabled)
+            {
+                metricConfig.WithReporting(
+                    report =>
+                        report.WithDatadog(config.GetValue(DATADOG_APIKEY),
+                            Environment.MachineName,
+                            config.GetValue(DATADOG_ROOTNAMESPACE),
+                            TimeSpan.FromSeconds(1)));
+            }
+
+            var graphiteEnabled = config.GetValue(GRAPHITE_ENABLED, false);
+            if (graphiteEnabled)
+            {
+                var gs = new TcpGraphiteSender(config.GetValue(GRAPHITE_HOST), config.GetValue(GRAPHITE_PORT, 0));
+                var gr = new StatsDGraphiteReport(gs, config.GetValue(GRAPHITE_ROOTNAMESPACE, string.Empty));
+                
+                metricConfig.WithReporting(report => report.WithReport(gr, TimeSpan.FromSeconds(1)));
+            }
+        }
+
+        //
+        // Summary:
+        //     A counter is a simple incrementing and decrementing 64-bit integer. Ex number
+        //     of active requests.
+        //
+        // Parameters:
+        //   name:
+        //     Name of the metric. Must be unique across all counters in this context.
+        //
+        //   unit:
+        //     Description of what the is being measured ( Unit.Requests , Unit.Items etc )
+        //     .
+        //
+        //   tags:
+        //     Optional set of tags that can be associated with the metric. Tags can be string
+        //     array or comma separated values in a string. ex: tags: "tag1,tag2" or tags: new[]
+        //     {"tag1", "tag2"}
+        //
+        // Returns:
+        //     Reference to the metric
+        public static Counter Counter(string name, Unit unit, MetricTags tags = default(MetricTags))
+        {
+            return Metric.Counter(name, unit, tags);
+        }
+
+        //
+        // Summary:
+        //     A gauge is the simplest metric type. It just returns a value. This metric is
+        //     suitable for instantaneous values.
+        //
+        // Parameters:
+        //   name:
+        //     Name of this gauge metric. Must be unique across all gauges in this context.
+        //
+        //   valueProvider:
+        //     Function that returns the value for the gauge.
+        //
+        //   unit:
+        //     Description of want the value represents ( Unit.Requests , Unit.Items etc ) .
+        //
+        //   tags:
+        //     Optional set of tags that can be associated with the metric.
+        //
+        // Returns:
+        //     Reference to the gauge
+        public static void Gauge(string name, Func<double> valueProvider, Unit unit,
+            MetricTags tags = default(MetricTags))
+        {
+            Metric.Gauge(name, valueProvider, unit, tags);
+        }
+
+        //
+        // Summary:
+        //     A Histogram measures the distribution of values in a stream of data: e.g., the
+        //     number of results returned by a search.
+        //
+        // Parameters:
+        //   name:
+        //     Name of the metric. Must be unique across all histograms in this context.
+        //
+        //   unit:
+        //     Description of what the is being measured ( Unit.Requests , Unit.Items etc )
+        //     .
+        //
+        //   samplingType:
+        //     Type of the sampling to use (see SamplingType for details ).
+        //
+        //   tags:
+        //     Optional set of tags that can be associated with the metric.
+        //
+        // Returns:
+        //     Reference to the metric
+        public static Histogram Histogram(string name, Unit unit, SamplingType samplingType = SamplingType.Default,
+            MetricTags tags = default(MetricTags))
+        {
+            return Metric.Histogram(name, unit, samplingType, tags);
+        }
+
+        //
+        // Summary:
+        //     A meter measures the rate at which a set of events occur, in a few different
+        //     ways. This metric is suitable for keeping a record of now often something happens
+        //     ( error, request etc ).
+        //
+        // Parameters:
+        //   name:
+        //     Name of the metric. Must be unique across all meters in this context.
+        //
+        //   unit:
+        //     Description of what the is being measured ( Unit.Requests , Unit.Items etc )
+        //     .
+        //
+        //   rateUnit:
+        //     Time unit for rates reporting. Defaults to Second ( occurrences / second ).
+        //
+        //   tags:
+        //     Optional set of tags that can be associated with the metric.
+        //
+        // Returns:
+        //     Reference to the metric
+        //
+        // Remarks:
+        //     The mean rate is the average rate of events. It’s generally useful for trivia,
+        //     but as it represents the total rate for your application’s entire lifetime (e.g.,
+        //     the total number of requests handled, divided by the number of seconds the process
+        //     has been running), it doesn’t offer a sense of recency. Luckily, meters also
+        //     record three different exponentially-weighted moving average rates: the 1-, 5-,
+        //     and 15-minute moving averages.
+        public static Meter Meter(string name, Unit unit, TimeUnit rateUnit = TimeUnit.Seconds,
+            MetricTags tags = default(MetricTags))
+        {
+            return Metric.Meter(name, unit, rateUnit, tags);
+        }
+
+        //
+        // Summary:
+        //     Register a performance counter as a Gauge metric.
+        //
+        // Parameters:
+        //   name:
+        //     Name of this gauge metric. Must be unique across all gauges in this context.
+        //
+        //   counterCategory:
+        //     Category of the performance counter
+        //
+        //   counterName:
+        //     Name of the performance counter
+        //
+        //   counterInstance:
+        //     Instance of the performance counter
+        //
+        //   unit:
+        //     Description of want the value represents ( Unit.Requests , Unit.Items etc ) .
+        //
+        //   tags:
+        //     Optional set of tags that can be associated with the metric.
+        //
+        // Returns:
+        //     Reference to the gauge
+        public static void PerformanceCounter(string name, string counterCategory, string counterName,
+            string counterInstance, Unit unit, MetricTags tags = default(MetricTags))
+        {
+            Metric.PerformanceCounter(name, counterCategory, counterName, counterInstance, unit, tags);
+        }
+
+        //
+        // Summary:
+        //     A timer is basically a histogram of the duration of a type of event and a meter
+        //     of the rate of its occurrence. Metrics.Metric.Histogram(System.String,Metrics.Unit,Metrics.SamplingType,Metrics.MetricTags)
+        //     and Metrics.Metric.Meter(System.String,Metrics.Unit,Metrics.TimeUnit,Metrics.MetricTags)
+        //
+        // Parameters:
+        //   name:
+        //     Name of the metric. Must be unique across all timers in this context.
+        //
+        //   unit:
+        //     Description of what the is being measured ( Unit.Requests , Unit.Items etc )
+        //     .
+        //
+        //   samplingType:
+        //     Type of the sampling to use (see SamplingType for details ).
+        //
+        //   rateUnit:
+        //     Time unit for rates reporting. Defaults to Second ( occurrences / second ).
+        //
+        //   durationUnit:
+        //     Time unit for reporting durations. Defaults to Milliseconds.
+        //
+        //   tags:
+        //     Optional set of tags that can be associated with the metric.
+        //
+        // Returns:
+        //     Reference to the metric
+        public static Timer Timer(string name, Unit unit, SamplingType samplingType = SamplingType.Default,
+            TimeUnit rateUnit = TimeUnit.Seconds, TimeUnit durationUnit = TimeUnit.Milliseconds,
+            MetricTags tags = default(MetricTags))
+        {
+            return Metric.Timer(name, unit, samplingType, rateUnit, durationUnit, tags);
+        }
+    }
+}

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.1.0")]
-[assembly: AssemblyFileVersion("17.2.1.0")]
+[assembly: AssemblyVersion("17.2.2.0")]
+[assembly: AssemblyFileVersion("17.2.2.0")]

--- a/GuaranteedRate.Sextant/app.config
+++ b/GuaranteedRate.Sextant/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/GuaranteedRate.Sextant/packages.config
+++ b/GuaranteedRate.Sextant/packages.config
@@ -1,8 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="5.4.0" targetFramework="net45" />
-  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
-  <package id="NEST" version="5.4.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="Elasticsearch.Net" version="5.4.0" targetFramework="net452" />
+  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net452" />
+  <package id="Metrics.NET" version="0.5.0-pre" targetFramework="net452" />
+  <package id="Metrics.NET.Datadog" version="1.0.0" targetFramework="net452" />
+  <package id="Metrics.NET.Graphite" version="0.5.0-pre" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
+  <package id="NEST" version="5.4.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
 </packages>

--- a/GuaranteedRate.Util.IndexFields/App.config
+++ b/GuaranteedRate.Util.IndexFields/App.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/GuaranteedRate.Util.IndexFields/GuaranteedRate.Util.IndexFields.csproj
+++ b/GuaranteedRate.Util.IndexFields/GuaranteedRate.Util.IndexFields.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GuaranteedRate.Util.IndexFields</RootNamespace>
     <AssemblyName>GuaranteedRate.Util.IndexFields</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -166,7 +166,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/GuaranteedRate.Util.IndexFields/packages.config
+++ b/GuaranteedRate.Util.IndexFields/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net45" />
+  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net452" />
 </packages>

--- a/LoggingTestRig/App.config
+++ b/LoggingTestRig/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/LoggingTestRig/LoggingTestRig.csproj
+++ b/LoggingTestRig/LoggingTestRig.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LoggingTestRig</RootNamespace>
     <AssemblyName>LoggingTestRig</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -130,6 +130,18 @@
       <HintPath>..\packages\EncompassSDK.Complete.17.2.0.2\lib\net45\Jed.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Metrics, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Metrics.NET.0.5.0-pre\lib\net45\Metrics.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Metrics.NET.Datadog, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Metrics.NET.Datadog.1.0.0\lib\net452\Metrics.NET.Datadog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Metrics.NET.Graphite, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Metrics.NET.Graphite.0.5.0-pre\lib\net45\Metrics.NET.Graphite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Nest, Version=5.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
       <HintPath>..\packages\NEST.5.4.0\lib\net45\Nest.dll</HintPath>
       <Private>True</Private>
@@ -180,8 +192,12 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GuaranteedRate.Sextant\GuaranteedRate.Sextant.csproj">

--- a/LoggingTestRig/Program.cs
+++ b/LoggingTestRig/Program.cs
@@ -8,6 +8,7 @@ using GuaranteedRate.Sextant.Logging.Loggly;
 using GuaranteedRate.Sextant.Metrics;
 using GuaranteedRate.Sextant.Metrics.Datadog;
 using GuaranteedRate.Sextant.Metrics.Graphite;
+using Metrics;
 
 namespace LoggingTestRig
 {
@@ -33,15 +34,42 @@ namespace LoggingTestRig
             Logger.Error("SextantTestRig", "Test error message");
             Logger.Fatal("SextantTestRig", "Test fatal message");
 
+            #region Simple Metrics 
+
             var datadog = new DatadogReporter(config);
             var graphite = new GraphiteReporter(config);
 
-            Metrics.AddReporter(datadog);
-            Metrics.AddReporter(graphite);
+            SimpleMetrics.AddReporter(datadog);
+            SimpleMetrics.AddReporter(graphite);
 
-            Metrics.AddGauge("SextantTestRig.Gauge", 10);
-            Metrics.AddCounter("SextantTestRig.Counter", 10);
-            Metrics.AddMeter("SextantTestRig.Meter", 10);
+            SimpleMetrics.AddGauge("SextantTestRig.Gauge", 10);
+            SimpleMetrics.AddCounter("SextantTestRig.Counter", 10);
+            SimpleMetrics.AddMeter("SextantTestRig.Meter", 10);
+
+            #endregion
+
+            #region StatsD Metrics
+
+            StatsDMetrics.Setup(config);
+
+            var timer = StatsDMetrics.Timer("sextant-statd-tests-timer", Unit.Calls);
+            Random r = new Random();
+            
+            timer.StartRecording();
+
+            var counter = StatsDMetrics.Counter("sextant-statd-tests-counter", Unit.Events, MetricTags.None);
+            counter.Increment(r.Next(0, 100));
+            counter.Increment(r.Next(0, 10));
+            counter.Increment(r.Next(0, 10));
+            counter.Increment(r.Next(0, 10));
+            counter.Increment(r.Next(0, 10));
+            counter.Increment(r.Next(0, 10));
+            counter.Increment(r.Next(0, 10));
+            counter.Increment(r.Next(0, 10));
+            
+            timer.EndRecording();
+
+            #endregion
 
             Console.WriteLine("press enter to quit.");
             Console.ReadLine();

--- a/LoggingTestRig/packages.config
+++ b/LoggingTestRig/packages.config
@@ -1,8 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="5.4.0" targetFramework="net45" />
-  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
-  <package id="NEST" version="5.4.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net45" />
+  <package id="Elasticsearch.Net" version="5.4.0" targetFramework="net452" />
+  <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net452" />
+  <package id="Metrics.NET" version="0.5.0-pre" targetFramework="net452" />
+  <package id="Metrics.NET.Datadog" version="1.0.0" targetFramework="net452" />
+  <package id="Metrics.NET.Graphite" version="0.5.0-pre" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
+  <package id="NEST" version="5.4.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ Random r = new Random();
 timer.StartRecording();
 
 var counter = StatsDMetrics.Counter("sextant-statd-tests-counter", 
-										Unit.Events, 
-										MetricTags.None);
+				    Unit.Events, 
+				    MetricTags.None);
 counter.Increment(r.Next(0, 100));
 counter.Increment(r.Next(0, 10));
 counter.Increment(r.Next(0, 10));

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ freeing your application main thread to continue with other work.
 
 ### Metrics
 
-**Metrics** is a static holding object that can contain any number of `IReporter` objects.  Once a reporter is registered with `Metrics` it will be called each time `Metrics` is invoked in your Application
+**SimpleMetrics** is a static holding object that can contain any number of `IReporter` objects.  Once a reporter is registered with `Metrics` it will be called each time `Metrics` is invoked in your Application
 
 Sample usage
 ```csharp
@@ -138,13 +138,44 @@ config.Init(System.IO.File.ReadAllText("SextantConfigTest.json"));
 var datadog = new DatadogReporter(config);
 var graphite = new GraphiteReporter(config);
 
-Metrics.AddReporter(datadog);
-Metrics.AddReporter(graphite);
+SimpleMetrics.AddReporter(datadog);
+SimpleMetrics.AddReporter(graphite);
 
-Metrics.AddGauge("SextantTestRig.Gauge", 10);
-Metrics.AddCounter("SextantTestRig.Counter", 10);
-Metrics.AddMeter("SextantTestRig.Meter", 10);
+SimpleMetrics.AddGauge("SextantTestRig.Gauge", 10);
+SimpleMetrics.AddCounter("SextantTestRig.Counter", 10);
+SimpleMetrics.AddMeter("SextantTestRig.Meter", 10);
+```
 
+- An example usage of `Metrics` in action can be found in [LoggingTestRig](LoggingTestRig/Program.cs)
+
+
+**StatsDMetrics** is a static holding object that emits metrics out to [Metrics.NET](https://github.com/Recognos/Metrics.NET) compliant reporters
+
+Sample usage
+```csharp
+var config = new JsonEncompassConfig();
+config.Init(System.IO.File.ReadAllText("SextantConfigTest.json"));
+                
+StatsDMetrics.Setup(config);
+
+var timer = StatsDMetrics.Timer("sextant-statd-tests-timer", Unit.Calls);
+Random r = new Random();
+            
+timer.StartRecording();
+
+var counter = StatsDMetrics.Counter("sextant-statd-tests-counter", 
+										Unit.Events, 
+										MetricTags.None);
+counter.Increment(r.Next(0, 100));
+counter.Increment(r.Next(0, 10));
+counter.Increment(r.Next(0, 10));
+counter.Increment(r.Next(0, 10));
+counter.Increment(r.Next(0, 10));
+counter.Increment(r.Next(0, 10));
+counter.Increment(r.Next(0, 10));
+counter.Increment(r.Next(0, 10));
+            
+timer.EndRecording();
 ```
 
 - An example usage of `Metrics` in action can be found in [LoggingTestRig](LoggingTestRig/Program.cs)


### PR DESCRIPTION
## v17.2.2.0 / 2017 JUl 26
> This release intruduces the concept of StatsD driven metrics tracking.  We are leveraging [Metrics.NET](https://github.com/Recognos/Metrics.NET)
to backbone the effort of transposing metrics into StatsD compliant metrics for consumption by our third party reporters.  
We have elected to supoort Graphite with the `GraphiteReporter` from [Metrics.NET.Graphite](https://github.com/Recognos/Metrics.NET.Graphite) and
Datadog with the `DatadogReporter` from  [Metrics.NET.Datadog](https://github.com/danzel/Metrics.NET.Datadog)
* **Add** - `SimpleMetrics` and `StatsDMetrics` as available Metrics trackers
* **Update** - Sextant has been rolled up to .NET 4.5.2 to utilize Metrics.NET 

```csharp
[GuaranteedRate.Sextant "17.2.2.0"]
```