### PR TITLE
Bugfix to throw a meaningful exception if an `AsyncEventReporter` does not have a base url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## v17.2.2.1 / 2017 Jul 27
 * **Fix** - Bugfix to throw a meaningful exception if an `AsyncEventReporter` has been created without a base url
 
+```csharp
+[GuaranteedRate.Sextant "17.2.2.1"]
+```
+
 ## v17.2.2.0 / 2017 Jul 26
 > This release intruduces the concept of StatsD driven metrics tracking.  We are leveraging [Metrics.NET](https://github.com/Recognos/Metrics.NET)
 to backbone the effort of transposing metrics into StatsD compliant metrics for consumption by our third party reporters.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## v17.2.2.0 / 2017 JUl 26
+## v17.2.2.1 / 2017 Jul 27
+* **Fix** - Bugfix to throw a meaningful exception if an `AsyncEventReporter` has been created without a base url
+
+## v17.2.2.0 / 2017 Jul 26
 > This release intruduces the concept of StatsD driven metrics tracking.  We are leveraging [Metrics.NET](https://github.com/Recognos/Metrics.NET)
 to backbone the effort of transposing metrics into StatsD compliant metrics for consumption by our third party reporters.  
 We have elected to supoort Graphite with the `GraphiteReporter` from [Metrics.NET.Graphite](https://github.com/Recognos/Metrics.NET.Graphite) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## v17.2.2.1 / 2017 Jul 27
 * **Fix** - Bugfix to throw a meaningful exception if an `AsyncEventReporter` has been created without a base url
 * **Fix** - Bugfix to correctly look for `LogglyLogAppender.Tags` in configuration files for the `LogglyLogAppender`
-
+* **Fix** - Correct a regression that was preventing `SecureAsyncEventReporter` from settings it's authorization header
+ 
 ```csharp
 [GuaranteedRate.Sextant "17.2.2.1"]
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v17.2.2.1 / 2017 Jul 27
 * **Fix** - Bugfix to throw a meaningful exception if an `AsyncEventReporter` has been created without a base url
+* **Fix** - Bugfix to correctly look for `LogglyLogAppender.Tags` in configuration files for the `LogglyLogAppender`
 
 ```csharp
 [GuaranteedRate.Sextant "17.2.2.1"]

--- a/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
@@ -29,7 +29,7 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
         public static string LOGGLY_INFO = "LogglyLogAppender.Info.Enabled";
         public static string LOGGLY_DEBUG = "LogglyLogAppender.Debug.Enabled";
         public static string LOGGLY_FATAL = "LogglyLogAppender.Fatal.Enabled";
-        public static string LOGGLY_TAGS = "Logger.Tags";
+        public static string LOGGLY_TAGS = "LogglyLogAppender.Tags";
 
         #endregion
 

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.2.0")]
-[assembly: AssemblyFileVersion("17.2.2.0")]
+[assembly: AssemblyVersion("17.2.2.1")]
+[assembly: AssemblyFileVersion("17.2.2.1")]

--- a/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
@@ -48,6 +48,11 @@ namespace GuaranteedRate.Sextant.WebClients
         
         public AsyncEventReporter(string url, int queueSize = DEFAULT_QUEUE_SIZE, int retries = DEFAULT_RETRIES)
         {
+            if (string.IsNullOrEmpty(url))
+            {
+                throw new ArgumentNullException("url", "Base URL must be provided");
+            }
+
             _eventQueue = new BlockingCollection<object>(new ConcurrentQueue<object>(), queueSize);
             _retries = retries;
             CreateClient(url);

--- a/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
@@ -147,17 +147,6 @@ namespace GuaranteedRate.Sextant.WebClients
             return true;
         }
 
-        /**
-         * This is an empty method that allows subclasses to add 
-         * additional functionality
-         * 
-         */
-
-        protected virtual void ExtraSetup(WebRequest webRequest)
-        {
-
-        }
-
         protected virtual bool PostEvent(object data)
         {
             try

--- a/GuaranteedRate.Sextant/WebClients/SecureAsyncEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/SecureAsyncEventReporter.cs
@@ -1,22 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
+using System.Net.Http.Headers;
 
 namespace GuaranteedRate.Sextant.WebClients
 {
     public class SecureAsyncEventReporter : AsyncEventReporter
     {
-        public string authorization { get; set; }
-
-        protected override void ExtraSetup(WebRequest webRequest)
-        {
-            webRequest.Headers.Add("Authorization:" + authorization);
-        }
-
-        public SecureAsyncEventReporter(string url, int queueSize = DEFAULT_QUEUE_SIZE, int retries = DEFAULT_RETRIES)
+        public SecureAsyncEventReporter(string url, string authorization, int queueSize = DEFAULT_QUEUE_SIZE,
+            int retries = DEFAULT_RETRIES)
             : base(url, queueSize, retries)
         {
+            if (!string.IsNullOrEmpty(authorization))
+            {
+                Client.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(authorization);
+            }
         }
     }
 }


### PR DESCRIPTION
## v17.2.2.1 / 2017 Jul 27
* **Fix** - Bugfix to throw a meaningful exception if an `AsyncEventReporter` has been created without a base url
* **Fix** - Bugfix to correctly look for `LogglyLogAppender.Tags` in configuration files for the `LogglyLogAppender`
* **Fix** - Correct regression that was preventing `SecureAsyncEventReporter` from settings it's authorization header
 
```csharp
[GuaranteedRate.Sextant "17.2.2.1"]
```