### PR TITLE
Include reportable fields when diff'ing Encompass Environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,7 @@ _Pvt_Extensions
 # FAKE - F# Make
 .fake/
 /LoggingTestRig/SextantConfigTest.json
+
+# Mac / Parallels
+.DS_Store
+._.DS_Store

--- a/GuaranteedRate.Sextant.CustomFieldComparer/FieldExtractor.cs
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/FieldExtractor.cs
@@ -1,0 +1,64 @@
+﻿using EllieMae.Encompass.BusinessObjects.Loans;
+using EllieMae.Encompass.Client;
+using Newtonsoft.Json;
+
+namespace GuaranteedRate.Sextant.CustomFieldComparer
+{
+    public class FieldExtractor
+    {
+        private readonly Session _session;
+        private readonly string _filePath;
+        private readonly bool _includeAll;
+
+        public FieldExtractor(Session session, string baseFilePath, bool onlyCustomFields)
+        {
+            EncompassUtils.FieldUtils.session = session;
+            _session = session;
+            _filePath = baseFilePath;
+            _includeAll = !onlyCustomFields;
+        }
+
+        public void Extract()
+        {
+            if (_includeAll)
+            {
+                Extract(_session.Loans.FieldDescriptors.StandardFields, _filePath);
+                Extract(_session.Loans.FieldDescriptors.VirtualFields, _filePath);
+            }
+            Extract(_session.Loans.FieldDescriptors.CustomFields, _filePath);
+        }
+
+        private static bool WriteFieldToFile(string filePath, string content)
+        {
+            if (System.IO.File.Exists(filePath))
+            {
+                if (System.IO.File.ReadAllText(filePath) == content)
+                {
+                    return false;
+                }
+                System.IO.File.Delete(filePath);
+            }
+            using (var sw = System.IO.File.CreateText(filePath))
+            {
+                sw.Write(content);
+                sw.Flush();
+            }
+            return true;
+        }
+
+        private void Extract(FieldDescriptors fieldCollection, string outPath)
+        {
+            foreach (FieldDescriptor field in fieldCollection)
+            {
+                var filePath = outPath + field.FieldID + ".json";
+                var fieldDesc = ExpandField(field);
+                WriteFieldToFile(filePath, fieldDesc);
+            }
+        }
+
+        private string ExpandField(FieldDescriptor field)
+        {
+            return JsonConvert.SerializeObject(field, Formatting.Indented);
+        }
+    }
+}

--- a/GuaranteedRate.Sextant.CustomFieldComparer/FieldExtractor.cs
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/FieldExtractor.cs
@@ -1,5 +1,7 @@
 ﻿using EllieMae.Encompass.BusinessObjects.Loans;
 using EllieMae.Encompass.Client;
+using EllieMae.Encompass.Collections;
+using EllieMae.Encompass.Reporting;
 using Newtonsoft.Json;
 
 namespace GuaranteedRate.Sextant.CustomFieldComparer
@@ -26,6 +28,7 @@ namespace GuaranteedRate.Sextant.CustomFieldComparer
                 Extract(_session.Loans.FieldDescriptors.VirtualFields, _filePath);
             }
             Extract(_session.Loans.FieldDescriptors.CustomFields, _filePath);
+            ExtractReporting(_filePath);
         }
 
         private static bool WriteFieldToFile(string filePath, string content)
@@ -46,6 +49,17 @@ namespace GuaranteedRate.Sextant.CustomFieldComparer
             return true;
         }
 
+        private void ExtractReporting(string outPath)
+        {
+            ReportingFieldDescriptorList reportableFields = _session.Reports.GetReportingDatabaseFields();
+            foreach (ReportingFieldDescriptor field in reportableFields)
+            {
+                var filePath = outPath + "REPORTING-" + field.FieldID + ".json";
+                var fieldDesc = ExpandField(field);
+                WriteFieldToFile(filePath, fieldDesc);
+            }
+        }
+
         private void Extract(FieldDescriptors fieldCollection, string outPath)
         {
             foreach (FieldDescriptor field in fieldCollection)
@@ -57,6 +71,11 @@ namespace GuaranteedRate.Sextant.CustomFieldComparer
         }
 
         private string ExpandField(FieldDescriptor field)
+        {
+            return JsonConvert.SerializeObject(field, Formatting.Indented);
+        }
+
+        private string ExpandField(ReportingFieldDescriptor field)
         {
             return JsonConvert.SerializeObject(field, Formatting.Indented);
         }

--- a/GuaranteedRate.Sextant.CustomFieldComparer/GuaranteedRate.Sextant.CustomFieldComparer.csproj
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/GuaranteedRate.Sextant.CustomFieldComparer.csproj
@@ -167,6 +167,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FieldExpander.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/GuaranteedRate.Sextant.CustomFieldComparer/GuaranteedRate.Sextant.CustomFieldComparer.csproj
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/GuaranteedRate.Sextant.CustomFieldComparer.csproj
@@ -167,7 +167,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="FieldExpander.cs" />
+    <Compile Include="FieldExtractor.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -287,7 +287,16 @@ It will show you MultiValue Index fields without known boundaries, as well as th
 
 ### GuaranteedRate.Sextant.CustomFieldComparer
 
-This tool queries an Encompass environment and serializes field definitions to text files.  This utility can be called by providing login credentials directly on the command line or by passing the path of a json config file.   This tool is useful for dumping say, a dev environment to one folder and a production environment to a second and using a merge compare tool to compare the two environments.
+This tool queries an Encompass environment and serializes field definitions to 
+text files.  There are two use cases where this tool is useful:
+
+1) It enables you to track custom and reporting field changes over time.  This
+is extremely useful for auditing and general change management.
+2) If you are supporting *multiple* Encompass environments having the field 
+definitions available as flat files makes comparing the lists for divergence
+managable.
+
+This utility can be called by providing login credentials directly on the command line or by passing the path of a json config file.   This tool is useful for dumping say, a dev environment to one folder and a production environment to a second and using a merge compare tool to compare the two environments.
 
 
 ## Developer Notes


### PR DESCRIPTION
Building on @brianbegygr 's work, some refactoring and adding reportable fields.

Next version should merge the two attribute groups into a single export
*AND* it should produce a consolidated, sorted, file/environment so that we can diff the fields using a tool like `diff`

@brianbegygr @jongear 