### PR TITLE
Generate a Single file *AND* add reportable field details to the field export

### DIFF
--- a/GuaranteedRate.Sextant.CustomFieldComparer/FieldExtractor.cs
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/FieldExtractor.cs
@@ -56,13 +56,13 @@ namespace GuaranteedRate.Sextant.CustomFieldComparer
             var keys = content.Keys.ToList();
             keys.Sort();
             StringBuilder manualJson = new StringBuilder();
-            manualJson.Append("[\n");
+            manualJson.AppendLine("[");
             foreach (var key in keys)
             {
                 //sortedContent.Add(content[key]); 
-                manualJson.Append("\t" + content[key] + ",\n");
+                manualJson.AppendLine(content[key] + ",");
             }
-            manualJson.Append("]\n");
+            manualJson.AppendLine("]");
             return manualJson.ToString();
         }
 

--- a/GuaranteedRate.Sextant.CustomFieldComparer/FieldExtractor.cs
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/FieldExtractor.cs
@@ -1,4 +1,8 @@
-﻿using EllieMae.Encompass.BusinessObjects.Loans;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EllieMae.Encompass.BusinessObjects.Loans;
 using EllieMae.Encompass.Client;
 using EllieMae.Encompass.Collections;
 using EllieMae.Encompass.Reporting;
@@ -9,29 +13,60 @@ namespace GuaranteedRate.Sextant.CustomFieldComparer
     public class FieldExtractor
     {
         private readonly Session _session;
-        private readonly string _filePath;
+        private readonly string _fullFile;
+        private readonly string _environmentPath;
         private readonly bool _includeAll;
+        private readonly IDictionary<string, string> _fullExport; 
 
-        public FieldExtractor(Session session, string baseFilePath, bool onlyCustomFields)
+        public FieldExtractor(Session session, string baseFilePath, bool onlyCustomFields, string environment)
         {
             EncompassUtils.FieldUtils.session = session;
             _session = session;
-            _filePath = baseFilePath;
+            _fullFile = baseFilePath + environment + ".json";
+            _environmentPath = baseFilePath + environment + "\\";
             _includeAll = !onlyCustomFields;
+            _fullExport = new Dictionary<string, string>();
         }
 
         public void Extract()
         {
             if (_includeAll)
             {
-                Extract(_session.Loans.FieldDescriptors.StandardFields, _filePath);
-                Extract(_session.Loans.FieldDescriptors.VirtualFields, _filePath);
+                Extract(_session.Loans.FieldDescriptors.StandardFields, _environmentPath);
+                Extract(_session.Loans.FieldDescriptors.VirtualFields, _environmentPath);
             }
-            Extract(_session.Loans.FieldDescriptors.CustomFields, _filePath);
-            ExtractReporting(_filePath);
+            Extract(_session.Loans.FieldDescriptors.CustomFields, _environmentPath);
+            ExtractReporting(_environmentPath);
+
+            var fullMonty = MergeAndSort(_fullExport);
+
+            WriteFieldToFile(_fullFile, fullMonty);
         }
 
-        private static bool WriteFieldToFile(string filePath, string content)
+        /// <summary>
+        /// Transform the master content dictionary into a sorted list of
+        /// field descriptions, then transform the list into a single giant
+        /// json array of field description maps.
+        /// </summary>
+        /// <param name="content"></param>
+        /// <returns></returns>
+        private string MergeAndSort(IDictionary<string, string> content)
+        {
+            IList<string> sortedContent = new List<string>();
+            var keys = content.Keys.ToList();
+            keys.Sort();
+            StringBuilder manualJson = new StringBuilder();
+            manualJson.Append("[\n");
+            foreach (var key in keys)
+            {
+                //sortedContent.Add(content[key]); 
+                manualJson.Append("\t" + content[key] + ",\n");
+            }
+            manualJson.Append("]\n");
+            return manualJson.ToString();
+        }
+
+        private bool WriteFieldToFile(string filePath, string content)
         {
             if (System.IO.File.Exists(filePath))
             {
@@ -56,6 +91,7 @@ namespace GuaranteedRate.Sextant.CustomFieldComparer
             {
                 var filePath = outPath + "REPORTING-" + field.FieldID + ".json";
                 var fieldDesc = ExpandField(field);
+                _fullExport["REPORTING-" +  field.FieldID] = fieldDesc;
                 WriteFieldToFile(filePath, fieldDesc);
             }
         }
@@ -66,6 +102,7 @@ namespace GuaranteedRate.Sextant.CustomFieldComparer
             {
                 var filePath = outPath + field.FieldID + ".json";
                 var fieldDesc = ExpandField(field);
+                _fullExport[field.FieldID] = fieldDesc;
                 WriteFieldToFile(filePath, fieldDesc);
             }
         }

--- a/GuaranteedRate.Sextant.CustomFieldComparer/FieldExtractor.cs
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/FieldExtractor.cs
@@ -38,29 +38,30 @@ namespace GuaranteedRate.Sextant.CustomFieldComparer
             Extract(_session.Loans.FieldDescriptors.CustomFields, _environmentPath);
             ExtractReporting(_environmentPath);
 
-            var fullMonty = MergeAndSort(_fullExport);
+            var fullMonty = BuildGiantJson(_fullExport);
 
             WriteFieldToFile(_fullFile, fullMonty);
         }
 
         /// <summary>
-        /// Transform the master content dictionary into a sorted list of
-        /// field descriptions, then transform the list into a single giant
-        /// json array of field description maps.
+        /// Content is a dictionary of fieldIds and json serializations of
+        /// field descriptions.
+        /// 
+        /// Rather than double serialize, or deal with double escaping, this
+        /// function is manually converting the descriptions into a json array
+        /// of descriptions.
         /// </summary>
         /// <param name="content"></param>
-        /// <returns></returns>
-        private string MergeAndSort(IDictionary<string, string> content)
+        /// <returns>A json array of field description maps, about 20megs</returns>
+        private string BuildGiantJson(IDictionary<string, string> content)
         {
-            IList<string> sortedContent = new List<string>();
             var keys = content.Keys.ToList();
             keys.Sort();
             StringBuilder manualJson = new StringBuilder();
             manualJson.AppendLine("[");
             foreach (var key in keys)
             {
-                //sortedContent.Add(content[key]); 
-                manualJson.AppendLine(content[key] + ",");
+                manualJson.Append(content[key]).AppendLine(",");
             }
             manualJson.AppendLine("]");
             return manualJson.ToString();

--- a/GuaranteedRate.Sextant.CustomFieldComparer/FullFieldDescription.cs
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/FullFieldDescription.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using EllieMae.Encompass.BusinessObjects.Loans;
+using EllieMae.Encompass.Reporting;
+
+namespace GuaranteedRate.Sextant.CustomFieldComparer
+{
+    /// <summary>
+    /// Merge FieldDescriptor and IReportingFieldDescriptor.
+    /// A field can have 0->many reporting fields
+    /// </summary>
+    public class FullFieldDescription
+    {
+        ///FieldDescriptor instead of IFieldDescriptor because not all fields 
+        /// are in the interface
+        public FieldDescriptor fieldDescriptor { get; set; }
+        public IList<IReportingFieldDescriptor> reportingFields { get; set; }
+    }
+}

--- a/GuaranteedRate.Sextant.CustomFieldComparer/GuaranteedRate.Sextant.CustomFieldComparer.csproj
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/GuaranteedRate.Sextant.CustomFieldComparer.csproj
@@ -171,6 +171,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FieldExtractor.cs" />
+    <Compile Include="FullFieldDescription.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/GuaranteedRate.Sextant.CustomFieldComparer/GuaranteedRate.Sextant.CustomFieldComparer.csproj
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/GuaranteedRate.Sextant.CustomFieldComparer.csproj
@@ -32,6 +32,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>GuaranteedRate.Sextant.CustomFieldComparer.Program</StartupObject>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Client, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
       <HintPath>..\packages\EncompassSDK.Complete.17.2.0.2\lib\net45\Client.dll</HintPath>
@@ -173,6 +176,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="encompass-config\devTesty.json" />
     <None Include="encompass-config\dev.json" />
     <None Include="packages.config" />
     <None Include="Sample.ps1" />

--- a/GuaranteedRate.Sextant.CustomFieldComparer/Program.cs
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/Program.cs
@@ -40,7 +40,7 @@ namespace GuaranteedRate.Sextant.CustomFieldComparer
             var primarySession = EncompassUtils.SessionUtils.GetEncompassSession(ops.EncompassPrimaryUrl, ops.EncompassUserName,
                 ops.EncompassPassword);
 
-            var fieldExtractor = new FieldExtractor(primarySession, ops.OutputPath, ops.CustomOnly);
+            var fieldExtractor = new FieldExtractor(primarySession, ops.OutputPath, ops.CustomOnly, ops.Environment);
             fieldExtractor.Extract();
             
             Console.WriteLine("Done!");
@@ -67,21 +67,23 @@ namespace GuaranteedRate.Sextant.CustomFieldComparer
     {
         [Option('e', "encompassUrl", HelpText = "Url of the server.")]
         public string EncompassPrimaryUrl { get; set; }
+
         [Option('u', "userName", HelpText = "UserName.")]
         public string EncompassUserName { get; set; }
+
         [Option('p', "Password", HelpText = "Password.")]
         public string EncompassPassword { get; set; }
 
         [Option('o', "OutputPath", HelpText = "Output Path.")]
-
         public string OutputPath { get; set; }
-        [Option('c', "CustomOnly", HelpText = "Custom Only.")]
 
+        [Option('c', "CustomOnly", HelpText = "Custom Only.")]
         public bool CustomOnly { get; set; }
 
         [Option('j', "JsonConfig", HelpText = "Path to the Json config to use instead of arguments.")]
-
         public string JsonConfig { get; set; }
-         
+
+        [Option('e', "Environment", HelpText = "Encompass Environment")]
+        public string Environment { get; set; }
     }
 }

--- a/GuaranteedRate.Sextant.CustomFieldComparer/encompass-config/dev.json
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/encompass-config/dev.json
@@ -3,5 +3,6 @@
   "EncompassPassword": "",
   "EncompassPrimaryUrl": "",
   "OutputPath": "",
+  "Environment": "",
   "CustomOnly": false
 }


### PR DESCRIPTION
Inching forward - this version adds a sorted array of field descriptions as a single file, which should make it easier to track differences with something like `diff`

Also adds reportable field tracking inside of the field.

Concerns not yet addressed:
* The file-per-field version doesn't handle deleted fields
* Reportable fields will be stored in different columns/tables in different environments.  This is fine, but will make diff'ing harder

@brianbegygr @jongear 
