### PR TITLE
Metrics.NET was released to stable, updating the nuget packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
+## v17.2.2.2 / 2017 Aug 04
+* **Update** - Metrics.NET was released to stable, updating the nuget packages to reflect the change
+```csharp
+[GuaranteedRate.Sextant "17.2.2.2"]
+```
+
 ## v17.2.2.1 / 2017 Jul 27
 * **Fix** - Bugfix to throw a meaningful exception if an `AsyncEventReporter` has been created without a base url
 * **Fix** - Bugfix to correctly look for `LogglyLogAppender.Tags` in configuration files for the `LogglyLogAppender`
 * **Fix** - Correct a regression that was preventing `SecureAsyncEventReporter` from settings it's authorization header
  
 ```csharp
-[GuaranteedRate.Sextant "17.2.2.1"]
+[GuaranteedRate.Sextant "17.2.2.2"]
 ```
 
 ## v17.2.2.0 / 2017 Jul 26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * **Fix** - Correct a regression that was preventing `SecureAsyncEventReporter` from settings it's authorization header
  
 ```csharp
-[GuaranteedRate.Sextant "17.2.2.2"]
+[GuaranteedRate.Sextant "17.2.2.1"]
 ```
 
 ## v17.2.2.0 / 2017 Jul 26

--- a/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
+++ b/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
@@ -127,8 +127,8 @@
       <HintPath>..\packages\EncompassSDK.Complete.17.2.0.2\lib\net45\Jed.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Metrics, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Metrics.NET.0.5.0-pre\lib\net45\Metrics.dll</HintPath>
+    <Reference Include="Metrics, Version=0.5.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Metrics.NET.0.5.3\lib\net45\Metrics.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Metrics.NET.Datadog, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -136,7 +136,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Metrics.NET.Graphite, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Metrics.NET.Graphite.0.5.0-pre\lib\net45\Metrics.NET.Graphite.dll</HintPath>
+      <HintPath>..\packages\Metrics.NET.Graphite.0.5.0\lib\net45\Metrics.NET.Graphite.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Nest, Version=5.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.2.1")]
-[assembly: AssemblyFileVersion("17.2.2.1")]
+[assembly: AssemblyVersion("17.2.2.2")]
+[assembly: AssemblyFileVersion("17.2.2.2")]

--- a/GuaranteedRate.Sextant/packages.config
+++ b/GuaranteedRate.Sextant/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="Elasticsearch.Net" version="5.4.0" targetFramework="net452" />
   <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net452" />
-  <package id="Metrics.NET" version="0.5.0-pre" targetFramework="net452" />
+  <package id="Metrics.NET" version="0.5.3" targetFramework="net452" />
   <package id="Metrics.NET.Datadog" version="1.0.0" targetFramework="net452" />
-  <package id="Metrics.NET.Graphite" version="0.5.0-pre" targetFramework="net452" />
+  <package id="Metrics.NET.Graphite" version="0.5.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="NEST" version="5.4.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />

--- a/LoggingTestRig/LoggingTestRig.csproj
+++ b/LoggingTestRig/LoggingTestRig.csproj
@@ -130,8 +130,8 @@
       <HintPath>..\packages\EncompassSDK.Complete.17.2.0.2\lib\net45\Jed.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Metrics, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Metrics.NET.0.5.0-pre\lib\net45\Metrics.dll</HintPath>
+    <Reference Include="Metrics, Version=0.5.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Metrics.NET.0.5.3\lib\net45\Metrics.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Metrics.NET.Datadog, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -139,7 +139,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Metrics.NET.Graphite, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Metrics.NET.Graphite.0.5.0-pre\lib\net45\Metrics.NET.Graphite.dll</HintPath>
+      <HintPath>..\packages\Metrics.NET.Graphite.0.5.0\lib\net45\Metrics.NET.Graphite.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Nest, Version=5.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">

--- a/LoggingTestRig/packages.config
+++ b/LoggingTestRig/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="Elasticsearch.Net" version="5.4.0" targetFramework="net452" />
   <package id="EncompassSDK.Complete" version="17.2.0.2" targetFramework="net452" />
-  <package id="Metrics.NET" version="0.5.0-pre" targetFramework="net452" />
+  <package id="Metrics.NET" version="0.5.3" targetFramework="net452" />
   <package id="Metrics.NET.Datadog" version="1.0.0" targetFramework="net452" />
-  <package id="Metrics.NET.Graphite" version="0.5.0-pre" targetFramework="net452" />
+  <package id="Metrics.NET.Graphite" version="0.5.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="NEST" version="5.4.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net452" />


### PR DESCRIPTION
## v17.2.2.2 / 2017 Aug 04
* **Update** - Metrics.NET was released to stable, updating the nuget packages to reflect the change
```csharp
[GuaranteedRate.Sextant "17.2.2.2"]
```