### PR TITLE
Added `Loggers.Setup()` to allow for the same configuration flow as seen with metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v17.2.2.3 / 2017 Aug 21
+* **Update** - Added `Loggers.Setup()` to allow for the same configuration flow as seen in `StatsDMetrics`
+
+[GuaranteedRate.Sextant "17.2.2.3"]
+```
+
 ## v17.2.2.2 / 2017 Aug 04
 * **Update** - Metrics.NET was released to stable, updating the nuget packages to reflect the change
 ```csharp

--- a/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
@@ -21,6 +21,7 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
 
         #region config mappings
 
+        public static string ELASTICSEARCH_ENABLED = "ElasticsearchLogAppender.Enabled";
         public static string ELASTICSEARCH_URL = "ElasticsearchLogAppender.Url";
         public static string ELASTICSEARCH_QUEUE_SIZE = "ElasticsearchLogAppender.QueueSize";
         public static string ELASTICSEARCH_RETRY_LIMIT = "ElasticsearchLogAppender.RetryLimit";

--- a/GuaranteedRate.Sextant/Logging/Logger.cs
+++ b/GuaranteedRate.Sextant/Logging/Logger.cs
@@ -2,6 +2,9 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using GuaranteedRate.Sextant.Config;
+using GuaranteedRate.Sextant.Logging.Elasticsearch;
+using GuaranteedRate.Sextant.Logging.Loggly;
 
 namespace GuaranteedRate.Sextant.Logging
 {
@@ -9,11 +12,27 @@ namespace GuaranteedRate.Sextant.Logging
     {
         private static volatile IList<ILogAppender> _reporters = new List<ILogAppender>();
         private static readonly object syncRoot = new Object();
+
         private const string ERROR = "ERROR";
         private const string WARN = "WARN";
         private const string INFO = "INFO";
         private const string DEBUG = "DEBUG";
         private const string FATAL = "FATAL";
+
+        public static void Setup(IEncompassConfig config)
+        {
+            var logglyEnabled = config.GetValue(LogglyLogAppender.LOGGLY_ENABLED, false);
+            if (logglyEnabled)
+            {
+                AddAppender(new LogglyLogAppender(config));
+            }
+
+            var elasticSearchEnabled = config.GetValue(ElasticsearchLogAppender.ELASTICSEARCH_ENABLED, false);
+            if (elasticSearchEnabled)
+            {
+                AddAppender(new ElasticsearchLogAppender(config));
+            }
+        }
 
         /// <summary>
         /// Initializes the logger with a single appender

--- a/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
@@ -19,6 +19,7 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
 
         #region config mappings
 
+        public static string LOGGLY_ENABLED = "LogglyLogAppender.Enabled";
         public static string LOGGLY_URL = "LogglyLogAppender.Url";
         public static string LOGGLY_APIKEY = "LogglyLogAppender.ApiKey";
         public static string LOGGLY_QUEUE_SIZE = "LogglyLogAppender.QueueSize";

--- a/GuaranteedRate.Sextant/Metrics/Datadog/DatadogReporter.cs
+++ b/GuaranteedRate.Sextant/Metrics/Datadog/DatadogReporter.cs
@@ -14,6 +14,8 @@ namespace GuaranteedRate.Sextant.Metrics.Datadog
 
         #region config mappings
 
+        public static string DATADOG_ROOTNAMESPACE = "DatadogReporter.RootNamespace";
+        public static string DATADOG_ENABLED = "DatadogReporter.Enabled";
         public static string DATADOG_URL = "DatadogReporter.Url";
         public static string DATADOG_APIKEY = "DatadogReporter.ApiKey";
         public static string DATADOG_QUEUE_SIZE = "DatadogReporter.QueueSize";

--- a/GuaranteedRate.Sextant/Metrics/Graphite/GraphiteReporter.cs
+++ b/GuaranteedRate.Sextant/Metrics/Graphite/GraphiteReporter.cs
@@ -15,6 +15,7 @@ namespace GuaranteedRate.Sextant.Metrics.Graphite
 
         #region config mappings
 
+        public static string GRAPHITE_ENABLED = "GraphiteReporter.Enabled";
         public static string GRAPHITE_HOST = "GraphiteReporter.Host";
         public static string GRAPHITE_PORT = "GraphiteReporter.Port";
         public static string GRAPHITE_QUEUE_SIZE = "GraphiteReporter.QueueSize";

--- a/GuaranteedRate.Sextant/Metrics/StatsDMetrics.cs
+++ b/GuaranteedRate.Sextant/Metrics/StatsDMetrics.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using GuaranteedRate.Sextant.Config;
+using GuaranteedRate.Sextant.Metrics.Datadog;
 using GuaranteedRate.Sextant.Metrics.Graphite;
 using Metrics;
 using Metrics.Graphite;
@@ -11,39 +12,26 @@ namespace GuaranteedRate.Sextant.Metrics
 {
     public class StatsDMetrics
     {
-        #region Config Mappings
-
-        private static string DATADOG_ENABLED = "DatadogReporter.Enabled";
-        private static string DATADOG_APIKEY = "DatadogReporter.ApiKey";
-        private static string DATADOG_ROOTNAMESPACE = "DatadogReporter.RootNamespace";
-
-        private static string GRAPHITE_ENABLED = "GraphiteReporter.Enabled";
-        private static string GRAPHITE_HOST = "GraphiteReporter.Host";
-        private static string GRAPHITE_PORT = "GraphiteReporter.Port";
-        private static string GRAPHITE_ROOTNAMESPACE = "GraphiteReporter.RootNamespace";
-
-        #endregion
-
         public static void Setup(IEncompassConfig config)
         {
             var metricConfig = Metric.Config;
 
-            var datadogEnabled = config.GetValue(DATADOG_ENABLED, false);
+            var datadogEnabled = config.GetValue(DatadogReporter.DATADOG_ENABLED, false);
             if (datadogEnabled)
             {
                 metricConfig.WithReporting(
                     report =>
-                        report.WithDatadog(config.GetValue(DATADOG_APIKEY),
+                        report.WithDatadog(config.GetValue(DatadogReporter.DATADOG_APIKEY),
                             Environment.MachineName,
-                            config.GetValue(DATADOG_ROOTNAMESPACE),
+                            config.GetValue(DatadogReporter.DATADOG_ROOTNAMESPACE),
                             TimeSpan.FromSeconds(1)));
             }
 
-            var graphiteEnabled = config.GetValue(GRAPHITE_ENABLED, false);
+            var graphiteEnabled = config.GetValue(GraphiteReporter.GRAPHITE_ENABLED, false);
             if (graphiteEnabled)
             {
-                var gs = new TcpGraphiteSender(config.GetValue(GRAPHITE_HOST), config.GetValue(GRAPHITE_PORT, 0));
-                var gr = new StatsDGraphiteReport(gs, config.GetValue(GRAPHITE_ROOTNAMESPACE, string.Empty));
+                var gs = new TcpGraphiteSender(config.GetValue(GraphiteReporter.GRAPHITE_HOST), config.GetValue(GraphiteReporter.GRAPHITE_PORT, 0));
+                var gr = new StatsDGraphiteReport(gs, config.GetValue(GraphiteReporter.GRAPHITE_ROOT_NAMESPACE, string.Empty));
                 
                 metricConfig.WithReporting(report => report.WithReport(gr, TimeSpan.FromSeconds(1)));
             }

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.2.2")]
-[assembly: AssemblyFileVersion("17.2.2.2")]
+[assembly: AssemblyVersion("17.2.2.3")]
+[assembly: AssemblyFileVersion("17.2.2.3")]


### PR DESCRIPTION
## v17.2.2.3 / 2017 Aug 21
* **Update** - Added `Loggers.Setup()` to allow for the same configuration flow as seen in `StatsDMetrics`

[GuaranteedRate.Sextant "17.2.2.3"]
```