### PR TITLE
Global tags for StatsD Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,14 +210,11 @@ in case of duplicates.
 
 * **Update**  - LoanDataUtils.cs will return clearer error messages. 
 
-
-
 ## v16.2.4.1 / 2016 Sep 15
 
 >Fixed an issue with a flipped boolean in json config init.
 
 * **Update**  - JsonEncompassConfig.cs was returning false on success fix to true. 
-
 
 ## v16.2.4.0 / 2016 Sep 13
 
@@ -645,14 +642,12 @@ a SSN
 * **Updated** - `LoanDataUtils.ExtractLoanFields` to call the 2 new functions
 
 ## v1.1.0 / 2015 Sept 4
-
-> Added `LoanDataUtils.ExtractMilestones` which returns a list of milestone data.
-> Added `LoanDataUtils.ExtractEverything` which runs all the extraction methods and returns a dictonary of the collections.
+* **Added** - `LoanDataUtils.ExtractMilestones` which returns a list of milestone data.
+* **Added** - `LoanDataUtils.ExtractEverything` which runs all the extraction methods and returns a dictonary of the collections.
 
 ## v1.0.1 / 2015 Aug 28
-
-> Update to FieldUtils to make it possible to collect a subset of fields instead of always getting all fields.
-> Revised the readme to be more descriptive
+* **Update** - Update to FieldUtils to make it possible to collect a subset of fields instead of always getting all fields.
+* **Update** - Revised the readme to be more descriptive
 
 ## v1.0.0 / 2015 Aug 27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
+## v17.2.2.4 / 2017 Aug 22
+* **Add** - Added ability to set global tags for `StatsDMetrics`
+
+```csharp
+[GuaranteedRate.Sextant "17.2.2.4"]
+```
+
 ## v17.2.2.3 / 2017 Aug 21
 * **Update** - Added `Loggers.Setup()` to allow for the same configuration flow as seen in `StatsDMetrics`
 
+```chsarp
 [GuaranteedRate.Sextant "17.2.2.3"]
 ```
 

--- a/GuaranteedRate.Sextant/Metrics/Datadog/DatadogReporter.cs
+++ b/GuaranteedRate.Sextant/Metrics/Datadog/DatadogReporter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using GuaranteedRate.Sextant.Config;
 using GuaranteedRate.Sextant.WebClients;
 using Newtonsoft.Json;
@@ -20,6 +21,7 @@ namespace GuaranteedRate.Sextant.Metrics.Datadog
         public static string DATADOG_APIKEY = "DatadogReporter.ApiKey";
         public static string DATADOG_QUEUE_SIZE = "DatadogReporter.QueueSize";
         public static string DATADOG_RETRY_LIMIT = "DatadogReporter.RetryLimit";
+        public static string DATADOG_TAGS = "DatadogReporter.Tags";
 
         #endregion
 
@@ -29,6 +31,16 @@ namespace GuaranteedRate.Sextant.Metrics.Datadog
                 config.GetValue(DATADOG_RETRY_LIMIT, 3))
         {
             Setup();
+            var tags = config.GetValue(DATADOG_TAGS, "");
+            if (!string.IsNullOrEmpty(tags))
+            {
+                var trimmedTags = tags.Split(',')
+                                      .Select(s => s.Trim())
+                                      .Where(s => !string.IsNullOrEmpty(s))
+                                      .ToList();
+
+                trimmedTags.ForEach(t => jsonTags.Add(t));
+            }
         }
 
         public DatadogReporter(string endpoint, string apiKey, int queueSize = 1000, int retries = 3)

--- a/GuaranteedRate.Sextant/Metrics/Graphite/GraphiteReporter.cs
+++ b/GuaranteedRate.Sextant/Metrics/Graphite/GraphiteReporter.cs
@@ -22,7 +22,8 @@ namespace GuaranteedRate.Sextant.Metrics.Graphite
         public static string GRAPHITE_RETRY_LIMIT = "GraphiteReporter.RetryLimit";
         public static string GRAPHITE_ROOT_NAMESPACE = "GraphiteReporter.RootNamespace";
         public static string GRAPHITE_TRACK_HOSTMACHINE = "GraphiteReporter.TrackHostmachine";
-        
+        public static string GRAPHITE_TAGS = "GraphiteReporter.Tags";
+
         #endregion
 
         public GraphiteReporter(IEncompassConfig config)

--- a/GuaranteedRate.Sextant/Metrics/StatsDMetrics.cs
+++ b/GuaranteedRate.Sextant/Metrics/StatsDMetrics.cs
@@ -12,13 +12,26 @@ namespace GuaranteedRate.Sextant.Metrics
 {
     public class StatsDMetrics
     {
+        private static MetricTags? _globalTags;
+        private static string STATSD_METRICS_TAGS = "StatsDMetrics.Tags";
+
         public static void Setup(IEncompassConfig config)
         {
             var metricConfig = Metric.Config;
-
+            
+            var statsdTags = config.GetValue(STATSD_METRICS_TAGS, "");
+            var globalTags = TrimTags(statsdTags);
+            
             var datadogEnabled = config.GetValue(DatadogReporter.DATADOG_ENABLED, false);
             if (datadogEnabled)
             {
+                var datadogTags = TrimTags(config.GetValue(DatadogReporter.DATADOG_TAGS));
+
+                if (datadogTags.Any())
+                {
+                    globalTags.AddRange(datadogTags);
+                }
+
                 metricConfig.WithReporting(
                     report =>
                         report.WithDatadog(config.GetValue(DatadogReporter.DATADOG_APIKEY),
@@ -30,11 +43,39 @@ namespace GuaranteedRate.Sextant.Metrics
             var graphiteEnabled = config.GetValue(GraphiteReporter.GRAPHITE_ENABLED, false);
             if (graphiteEnabled)
             {
+                var grapiteTags = TrimTags(config.GetValue(GraphiteReporter.GRAPHITE_TAGS));
+
+                if (grapiteTags.Any())
+                {
+                    globalTags.AddRange(grapiteTags);
+                }
+
                 var gs = new TcpGraphiteSender(config.GetValue(GraphiteReporter.GRAPHITE_HOST), config.GetValue(GraphiteReporter.GRAPHITE_PORT, 0));
                 var gr = new StatsDGraphiteReport(gs, config.GetValue(GraphiteReporter.GRAPHITE_ROOT_NAMESPACE, string.Empty));
                 
                 metricConfig.WithReporting(report => report.WithReport(gr, TimeSpan.FromSeconds(1)));
             }
+
+            if (globalTags.Any())
+            {
+                _globalTags = new MetricTags(globalTags);
+            }
+        }
+
+        private static List<string> TrimTags(string tags)
+        {
+            if (string.IsNullOrEmpty(tags))
+            {
+                return new List<string>();
+            }
+
+            var trimmedTags = tags
+                                .Split(',')
+                                .Select(s => s.Trim())
+                                .Where(s => !string.IsNullOrEmpty(s))
+                                .ToList();
+
+            return trimmedTags;
         }
 
         //
@@ -59,7 +100,25 @@ namespace GuaranteedRate.Sextant.Metrics
         //     Reference to the metric
         public static Counter Counter(string name, Unit unit, MetricTags tags = default(MetricTags))
         {
-            return Metric.Counter(name, unit, tags);
+            var tagList = new List<string>();
+            var metricTags = tags;
+
+            if (_globalTags.HasValue)
+            {
+                tagList.AddRange(_globalTags.Value.Tags);
+            }
+
+            if (tags.Tags.Any())
+            {
+                tagList.AddRange(tags.Tags);
+            }
+
+            if (tagList.Any())
+            {
+                metricTags = new MetricTags(tagList);
+            }
+
+            return Metric.Counter(name, unit, metricTags);
         }
 
         //
@@ -85,7 +144,25 @@ namespace GuaranteedRate.Sextant.Metrics
         public static void Gauge(string name, Func<double> valueProvider, Unit unit,
             MetricTags tags = default(MetricTags))
         {
-            Metric.Gauge(name, valueProvider, unit, tags);
+            var tagList = new List<string>();
+            var metricTags = tags;
+
+            if (_globalTags.HasValue)
+            {
+                tagList.AddRange(_globalTags.Value.Tags);
+            }
+
+            if (tags.Tags.Any())
+            {
+                tagList.AddRange(tags.Tags);
+            }
+
+            if (tagList.Any())
+            {
+                metricTags = new MetricTags(tagList);
+            }
+
+            Metric.Gauge(name, valueProvider, unit, metricTags);
         }
 
         //
@@ -112,7 +189,25 @@ namespace GuaranteedRate.Sextant.Metrics
         public static Histogram Histogram(string name, Unit unit, SamplingType samplingType = SamplingType.Default,
             MetricTags tags = default(MetricTags))
         {
-            return Metric.Histogram(name, unit, samplingType, tags);
+            var tagList = new List<string>();
+            var metricTags = tags;
+
+            if (_globalTags.HasValue)
+            {
+                tagList.AddRange(_globalTags.Value.Tags);
+            }
+
+            if (tags.Tags.Any())
+            {
+                tagList.AddRange(tags.Tags);
+            }
+
+            if (tagList.Any())
+            {
+                metricTags = new MetricTags(tagList);
+            }
+
+            return Metric.Histogram(name, unit, samplingType, metricTags);
         }
 
         //
@@ -148,7 +243,25 @@ namespace GuaranteedRate.Sextant.Metrics
         public static Meter Meter(string name, Unit unit, TimeUnit rateUnit = TimeUnit.Seconds,
             MetricTags tags = default(MetricTags))
         {
-            return Metric.Meter(name, unit, rateUnit, tags);
+            var tagList = new List<string>();
+            var metricTags = tags;
+
+            if (_globalTags.HasValue)
+            {
+                tagList.AddRange(_globalTags.Value.Tags);
+            }
+
+            if (tags.Tags.Any())
+            {
+                tagList.AddRange(tags.Tags);
+            }
+
+            if (tagList.Any())
+            {
+                metricTags = new MetricTags(tagList);
+            }
+
+            return Metric.Meter(name, unit, rateUnit, metricTags);
         }
 
         //
@@ -179,7 +292,25 @@ namespace GuaranteedRate.Sextant.Metrics
         public static void PerformanceCounter(string name, string counterCategory, string counterName,
             string counterInstance, Unit unit, MetricTags tags = default(MetricTags))
         {
-            Metric.PerformanceCounter(name, counterCategory, counterName, counterInstance, unit, tags);
+            var tagList = new List<string>();
+            var metricTags = tags;
+
+            if (_globalTags.HasValue)
+            {
+                tagList.AddRange(_globalTags.Value.Tags);
+            }
+
+            if (tags.Tags.Any())
+            {
+                tagList.AddRange(tags.Tags);
+            }
+
+            if (tagList.Any())
+            {
+                metricTags = new MetricTags(tagList);
+            }
+
+            Metric.PerformanceCounter(name, counterCategory, counterName, counterInstance, unit, metricTags);
         }
 
         //
@@ -214,7 +345,25 @@ namespace GuaranteedRate.Sextant.Metrics
             TimeUnit rateUnit = TimeUnit.Seconds, TimeUnit durationUnit = TimeUnit.Milliseconds,
             MetricTags tags = default(MetricTags))
         {
-            return Metric.Timer(name, unit, samplingType, rateUnit, durationUnit, tags);
+            var tagList = new List<string>();
+            var metricTags = tags;
+
+            if (_globalTags.HasValue)
+            {
+                tagList.AddRange(_globalTags.Value.Tags);
+            }
+
+            if (tags.Tags.Any())
+            {
+                tagList.AddRange(tags.Tags);
+            }
+
+            if (tagList.Any())
+            {
+                metricTags = new MetricTags(tagList);
+            }
+
+            return Metric.Timer(name, unit, samplingType, rateUnit, durationUnit, metricTags);
         }
     }
 }

--- a/GuaranteedRate.Sextant/Metrics/StatsDMetrics.cs
+++ b/GuaranteedRate.Sextant/Metrics/StatsDMetrics.cs
@@ -100,6 +100,13 @@ namespace GuaranteedRate.Sextant.Metrics
         //     Reference to the metric
         public static Counter Counter(string name, Unit unit, MetricTags tags = default(MetricTags))
         {
+            var metricTags = GenerateTags(tags);
+
+            return Metric.Counter(name, unit, metricTags);
+        }
+
+        private static MetricTags GenerateTags(MetricTags tags)
+        {
             var tagList = new List<string>();
             var metricTags = tags;
 
@@ -117,8 +124,7 @@ namespace GuaranteedRate.Sextant.Metrics
             {
                 metricTags = new MetricTags(tagList);
             }
-
-            return Metric.Counter(name, unit, metricTags);
+            return metricTags;
         }
 
         //
@@ -144,23 +150,7 @@ namespace GuaranteedRate.Sextant.Metrics
         public static void Gauge(string name, Func<double> valueProvider, Unit unit,
             MetricTags tags = default(MetricTags))
         {
-            var tagList = new List<string>();
-            var metricTags = tags;
-
-            if (_globalTags.HasValue)
-            {
-                tagList.AddRange(_globalTags.Value.Tags);
-            }
-
-            if (tags.Tags.Any())
-            {
-                tagList.AddRange(tags.Tags);
-            }
-
-            if (tagList.Any())
-            {
-                metricTags = new MetricTags(tagList);
-            }
+            var metricTags = GenerateTags(tags);
 
             Metric.Gauge(name, valueProvider, unit, metricTags);
         }
@@ -189,23 +179,7 @@ namespace GuaranteedRate.Sextant.Metrics
         public static Histogram Histogram(string name, Unit unit, SamplingType samplingType = SamplingType.Default,
             MetricTags tags = default(MetricTags))
         {
-            var tagList = new List<string>();
-            var metricTags = tags;
-
-            if (_globalTags.HasValue)
-            {
-                tagList.AddRange(_globalTags.Value.Tags);
-            }
-
-            if (tags.Tags.Any())
-            {
-                tagList.AddRange(tags.Tags);
-            }
-
-            if (tagList.Any())
-            {
-                metricTags = new MetricTags(tagList);
-            }
+            var metricTags = GenerateTags(tags);
 
             return Metric.Histogram(name, unit, samplingType, metricTags);
         }
@@ -243,23 +217,7 @@ namespace GuaranteedRate.Sextant.Metrics
         public static Meter Meter(string name, Unit unit, TimeUnit rateUnit = TimeUnit.Seconds,
             MetricTags tags = default(MetricTags))
         {
-            var tagList = new List<string>();
-            var metricTags = tags;
-
-            if (_globalTags.HasValue)
-            {
-                tagList.AddRange(_globalTags.Value.Tags);
-            }
-
-            if (tags.Tags.Any())
-            {
-                tagList.AddRange(tags.Tags);
-            }
-
-            if (tagList.Any())
-            {
-                metricTags = new MetricTags(tagList);
-            }
+            var metricTags = GenerateTags(tags);
 
             return Metric.Meter(name, unit, rateUnit, metricTags);
         }
@@ -292,23 +250,7 @@ namespace GuaranteedRate.Sextant.Metrics
         public static void PerformanceCounter(string name, string counterCategory, string counterName,
             string counterInstance, Unit unit, MetricTags tags = default(MetricTags))
         {
-            var tagList = new List<string>();
-            var metricTags = tags;
-
-            if (_globalTags.HasValue)
-            {
-                tagList.AddRange(_globalTags.Value.Tags);
-            }
-
-            if (tags.Tags.Any())
-            {
-                tagList.AddRange(tags.Tags);
-            }
-
-            if (tagList.Any())
-            {
-                metricTags = new MetricTags(tagList);
-            }
+            var metricTags = GenerateTags(tags);
 
             Metric.PerformanceCounter(name, counterCategory, counterName, counterInstance, unit, metricTags);
         }
@@ -345,23 +287,7 @@ namespace GuaranteedRate.Sextant.Metrics
             TimeUnit rateUnit = TimeUnit.Seconds, TimeUnit durationUnit = TimeUnit.Milliseconds,
             MetricTags tags = default(MetricTags))
         {
-            var tagList = new List<string>();
-            var metricTags = tags;
-
-            if (_globalTags.HasValue)
-            {
-                tagList.AddRange(_globalTags.Value.Tags);
-            }
-
-            if (tags.Tags.Any())
-            {
-                tagList.AddRange(tags.Tags);
-            }
-
-            if (tagList.Any())
-            {
-                metricTags = new MetricTags(tagList);
-            }
+            var metricTags = GenerateTags(tags);
 
             return Metric.Timer(name, unit, samplingType, rateUnit, durationUnit, metricTags);
         }

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.2.3")]
-[assembly: AssemblyFileVersion("17.2.2.3")]
+[assembly: AssemblyVersion("17.2.2.4")]
+[assembly: AssemblyFileVersion("17.2.2.4")]


### PR DESCRIPTION
## v17.2.2.4 / 2017 Aug 22
* **Add** - Added ability to set global tags for `StatsDMetrics`

```csharp
[GuaranteedRate.Sextant "17.2.2.4"]
```
