### PR TITLE
Added ability to add global runtime tags for `StatsDMetrics`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v17.2.2.5 / 2017 Aug 22
+* **Add** - Added ability to add global runtime tags for `StatsDMetrics`
+
+```csharp
+[GuaranteedRate.Sextant "17.2.2.5"]
+```
+
 ## v17.2.2.4 / 2017 Aug 22
 * **Add** - Added ability to set global tags for `StatsDMetrics`
 

--- a/GuaranteedRate.Sextant/Metrics/StatsDMetrics.cs
+++ b/GuaranteedRate.Sextant/Metrics/StatsDMetrics.cs
@@ -62,6 +62,21 @@ namespace GuaranteedRate.Sextant.Metrics
             }
         }
 
+        public static void AddGlobalTag(string tag)
+        {
+            if (!_globalTags.HasValue)
+            {
+                _globalTags = new MetricTags(tag);
+            }
+            else
+            {
+                var tags = _globalTags.Value.Tags.ToList();
+                var newTags = TrimTags(tag);
+                tags.AddRange(newTags);
+                _globalTags = new MetricTags(tags);
+            }
+        }
+
         private static List<string> TrimTags(string tags)
         {
             if (string.IsNullOrEmpty(tags))

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.2.4")]
-[assembly: AssemblyFileVersion("17.2.2.4")]
+[assembly: AssemblyVersion("17.2.2.5")]
+[assembly: AssemblyFileVersion("17.2.2.5")]


### PR DESCRIPTION
## v17.2.2.5 / 2017 Aug 22
* **Add** - Added ability to add global runtime tags for `StatsDMetrics`

```csharp
[GuaranteedRate.Sextant "17.2.2.5"]
```