### PR TITLE
Fix loggly searching regression and add support for global AddTag()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## v17.2.2.6 / 2017 Aug 28
 * **Fix** - Regression in Loggly support that was preventing logs from being searchable
 * **Add** - Added ability to add runtime tags to `Logger` via `Logger.AddTag()`
-
+* **Add** - Support for tagging in Elassticsearch
+ 
 ```csharp
 [GuaranteedRate.Sextant "17.2.2.6"]
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v17.2.2.6 / 2017 Aug 28
+* **Fix** - Regression in Loggly support that was preventing logs from being searchable
+* **Add** - Added ability to add runtime tags to `Logger` via `Logger.AddTag()`
+
+```csharp
+[GuaranteedRate.Sextant "17.2.2.6"]
+```
+
 ## v17.2.2.5 / 2017 Aug 22
 * **Add** - Added ability to add global runtime tags for `StatsDMetrics`
 

--- a/GuaranteedRate.Sextant/Logging/ConsoleLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/ConsoleLogAppender.cs
@@ -67,7 +67,7 @@ namespace GuaranteedRate.Sextant.Logging
 
         public void AddTag(string tag)
         {
-            
+            //tagging not supported for console log appender
         }
     }
 }

--- a/GuaranteedRate.Sextant/Logging/ConsoleLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/ConsoleLogAppender.cs
@@ -64,5 +64,10 @@ namespace GuaranteedRate.Sextant.Logging
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
         }
+
+        public void AddTag(string tag)
+        {
+            
+        }
     }
 }

--- a/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
@@ -13,6 +13,7 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
         private Uri _node;
         private ConnectionSettings _settings;
         private ElasticClient _client;
+        
         public bool DebugEnabled { get; private set; }
         public bool InfoEnabled { get; private set; }
         public bool WarnEnabled { get; private set; }
@@ -97,5 +98,11 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
 
             return true;
         }
+
+        public void AddTag(string tag)
+        {
+            //throw new NotImplementedException();
+        }
+
     }
 }

--- a/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
@@ -93,7 +93,7 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
             var loggerName = "undefined";
             if (fields.ContainsKey("loggerName"))
             {
-                loggerName = (string)fields["loggerName"];
+                loggerName = fields["loggerName"];
                 loggerName = loggerName.ToLower();
             }
 

--- a/GuaranteedRate.Sextant/Logging/ILogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/ILogAppender.cs
@@ -8,6 +8,7 @@ namespace GuaranteedRate.Sextant.Logging
     public interface ILogAppender
     {
         void Log(IDictionary<string, string> fields);
+        void AddTag(string tag);
         bool DebugEnabled { get; }
         bool InfoEnabled { get; }
         bool WarnEnabled { get; }

--- a/GuaranteedRate.Sextant/Logging/Logger.cs
+++ b/GuaranteedRate.Sextant/Logging/Logger.cs
@@ -59,6 +59,20 @@ namespace GuaranteedRate.Sextant.Logging
             }
         }
 
+        public static void AddTag(string tag)
+        {
+            lock(syncRoot)
+            {
+                if (_reporters != null)
+                {
+                    foreach (var reporter in _reporters)
+                    {
+                        reporter.AddTag(tag);
+                    }
+                }
+            }
+        }
+
         private static IDictionary<string, string> PopulateEvent(string loggerName, string level, string message)
         {
             IDictionary<string, string> fields = new ConcurrentDictionary<string, string>();

--- a/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using GuaranteedRate.Sextant.Config;
 using GuaranteedRate.Sextant.WebClients;
 
@@ -9,6 +8,9 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
 {
     public class LogglyLogAppender : AsyncEventReporter, ILogAppender
     {
+        private readonly string _url = "";
+        private readonly string _apiKey = "";
+
         protected override string Name { get; } = typeof(LogglyLogAppender).Name;
         private static ISet<string> _tags;
         public bool ErrorEnabled { get; set; }
@@ -36,6 +38,8 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
 
         public LogglyLogAppender(string url, string apiKey, int queueSize = 1000, int retries = 3) : base(CreateUrl(url, apiKey), queueSize, retries)
         {
+            _url = url;
+            _apiKey = apiKey;
             _tags = new HashSet<string>();
         }
 
@@ -44,21 +48,27 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
                 config.GetValue(LOGGLY_QUEUE_SIZE, 1000),
                 config.GetValue(LOGGLY_RETRY_LIMIT, 3))
         {
+            _url = config.GetValue(LOGGLY_URL);
+            _apiKey = config.GetValue(LOGGLY_APIKEY);
             _tags = new HashSet<string>();
             Setup(config);
         }
 
         protected static string CreateUrl(string url, string apiKey)
         {
-            return $"{url}/inputs/{apiKey}/tag";
+            var baseUrl = $"{url}/inputs/{apiKey}/tag";
+
+            if (_tags != null && _tags.Any())
+            {
+                var tagCsv = string.Join(",", _tags);
+                baseUrl += $"/{tagCsv}/";
+            }
+
+            return baseUrl;
         }
 
         protected void Setup(IEncompassConfig config)
         {
-            var url = CreateUrl(config.GetValue(LOGGLY_URL), config.GetValue(LOGGLY_APIKEY));
-
-            CreateClient(url);
-            
             var allEnabled = config.GetValue(LOGGLY_ALL, false);
             var errorEnabled = config.GetValue(LOGGLY_ERROR, false);
             var warnEnabled = config.GetValue(LOGGLY_WARN, false);
@@ -83,6 +93,10 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
                     AddTag(tag);
                 }
             }
+
+            var url = CreateUrl(config.GetValue(LOGGLY_URL), config.GetValue(LOGGLY_APIKEY));
+
+            CreateClient(url);
         }
 
         /// <summary>
@@ -95,32 +109,15 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
             if (!_tags.Contains(tag.Trim()))
             {
                 _tags.Add(tag.Trim());
+
+                var url = CreateUrl(_url, _apiKey);
+                CreateClient(url);
             }
         }
 
         public void Log(IDictionary<string, string> fields)
         {
-            if (fields != null)
-            {
-                fields["tag"] = string.Join(",", _tags);
-            }
-
             ReportEvent(fields);
-        }
-
-        private static string MakeTagCsv()
-        {
-            StringBuilder builder = new StringBuilder();
-            foreach (string tag in _tags)
-            {
-                if (!string.IsNullOrWhiteSpace(tag))
-                {
-                    builder.Append(tag).Append(",");
-                }
-            }
-            builder.Remove(builder.Length - 1, 1);
-
-            return builder.ToString();
         }
     }
 }

--- a/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using GuaranteedRate.Sextant.Config;
 using GuaranteedRate.Sextant.WebClients;
-using Newtonsoft.Json;
 
 namespace GuaranteedRate.Sextant.Logging.Loggly
 {
@@ -55,7 +55,9 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
 
         protected void Setup(IEncompassConfig config)
         {
-            CreateClient(config.GetValue(LOGGLY_URL));
+            var url = CreateUrl(config.GetValue(LOGGLY_URL), config.GetValue(LOGGLY_APIKEY));
+
+            CreateClient(url);
             
             var allEnabled = config.GetValue(LOGGLY_ALL, false);
             var errorEnabled = config.GetValue(LOGGLY_ERROR, false);
@@ -98,10 +100,12 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
 
         public void Log(IDictionary<string, string> fields)
         {
-            //Having Indented formatting makes the data format better in the Loggly
-            //Search screen
-            var json = JsonConvert.SerializeObject(fields, Formatting.Indented);
-            ReportEvent(json);
+            if (fields != null)
+            {
+                fields["tag"] = string.Join(",", _tags);
+            }
+
+            ReportEvent(fields);
         }
 
         private static string MakeTagCsv()

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.2.5")]
-[assembly: AssemblyFileVersion("17.2.2.5")]
+[assembly: AssemblyVersion("17.2.2.6")]
+[assembly: AssemblyFileVersion("17.2.2.6")]

--- a/LoggingTestRig/Program.cs
+++ b/LoggingTestRig/Program.cs
@@ -27,6 +27,7 @@ namespace LoggingTestRig
             Logger.AddAppender(console);
             Logger.AddAppender(loggly);
             Logger.AddAppender(elasticSearch);
+            Logger.AddTag("runtime-tag");
 
             Logger.Debug("SextantTestRig", "Test debug message");
             Logger.Info("SextantTestRig", "Test info message");


### PR DESCRIPTION
## v17.2.2.6 / 2017 Aug 28
* **Fix** - Regression in Loggly support that was preventing logs from being searchable
* **Add** - Added ability to add runtime tags to `Logger` via `Logger.AddTag()`

```csharp
[GuaranteedRate.Sextant "17.2.2.6"]
```