### PR TITLE
make log appenders respect configured log tolerance level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v17.2.2.7 / 2017 Aug 28
+* **Fix** - Fix regression that prevented loggers from filtering logs based on configured log level tolerance
+ 
+```csharp
+[GuaranteedRate.Sextant "17.2.2.7"]
+```
+
 ## v17.2.2.6 / 2017 Aug 28
 * **Fix** - Regression in Loggly support that was preventing logs from being searchable
 * **Add** - Added ability to add runtime tags to `Logger` via `Logger.AddTag()`

--- a/GuaranteedRate.Sextant/Logging/ConsoleLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/ConsoleLogAppender.cs
@@ -10,6 +10,7 @@ namespace GuaranteedRate.Sextant.Logging
     /// </summary>
     public class ConsoleLogAppender : ILogAppender
     {
+        public bool AllEnabled { get; private set; }
         public bool DebugEnabled { get; private set; }
         public bool InfoEnabled { get; private set; }
         public bool WarnEnabled { get; private set; }
@@ -34,32 +35,44 @@ namespace GuaranteedRate.Sextant.Logging
 
         protected void Setup(IEncompassConfig config)
         {
-            DebugEnabled = config.GetValue(CONSOLE_DEBUG, false);
-            InfoEnabled = config.GetValue(CONSOLE_INFO, false);
-            WarnEnabled = config.GetValue(CONSOLE_WARN, false);
-            ErrorEnabled = config.GetValue(CONSOLE_ERROR, true);
-            FatalEnabled = config.GetValue(CONSOLE_FATAL, true);
+            var allEnabled = config.GetValue(CONSOLE_ALL, true);
+            var errorEnabled = config.GetValue(CONSOLE_ERROR, true);
+            var warnEnabled = config.GetValue(CONSOLE_WARN, true);
+            var infoEnabled = config.GetValue(CONSOLE_INFO, true);
+            var debugEnabled = config.GetValue(CONSOLE_DEBUG, true);
+            var fatalEnabled = config.GetValue(CONSOLE_FATAL, true);
+
+            AllEnabled = allEnabled;
+            ErrorEnabled = allEnabled || errorEnabled;
+            WarnEnabled = allEnabled || warnEnabled;
+            InfoEnabled = allEnabled || infoEnabled;
+            DebugEnabled = allEnabled || debugEnabled;
+            FatalEnabled = allEnabled || fatalEnabled;
         }
 
         public void Log(IDictionary<string, string> fields)
         {
-            if (string.Equals(fields["level"], "debug", StringComparison.CurrentCultureIgnoreCase) && DebugEnabled)
+            if (AllEnabled)
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            if (string.Equals(fields["level"], "info", StringComparison.CurrentCultureIgnoreCase) && InfoEnabled)
+            else if (DebugEnabled && string.Equals(fields["level"], Logger.DEBUG, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            if (string.Equals(fields["level"], "warn", StringComparison.CurrentCultureIgnoreCase) && WarnEnabled)
+            else if (InfoEnabled && string.Equals(fields["level"], Logger.INFO, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            if (string.Equals(fields["level"], "error", StringComparison.CurrentCultureIgnoreCase) && ErrorEnabled)
+            else if (WarnEnabled && string.Equals(fields["level"], Logger.WARN, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            if (string.Equals(fields["level"], "fatal", StringComparison.CurrentCultureIgnoreCase) && FatalEnabled)
+            else if (ErrorEnabled && string.Equals(fields["level"], Logger.ERROR, StringComparison.CurrentCultureIgnoreCase))
+            {
+                Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
+            }
+            else if (FatalEnabled && string.Equals(fields["level"], Logger.FATAL, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }

--- a/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
@@ -16,6 +16,7 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
         private ConnectionSettings _settings;
         private ElasticClient _client;
         private static ISet<string> _tags;
+        public bool AllEnabled { get; set; }
         public bool DebugEnabled { get; private set; }
         public bool InfoEnabled { get; private set; }
         public bool WarnEnabled { get; private set; }
@@ -60,6 +61,7 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
             var debugEnabled = config.GetValue(ELASTICSEARCH_DEBUG, true);
             var fatalEnabled = config.GetValue(ELASTICSEARCH_FATAL, true);
 
+            AllEnabled = allEnabled;
             ErrorEnabled = allEnabled || errorEnabled;
             WarnEnabled = allEnabled || warnEnabled;
             InfoEnabled = allEnabled || infoEnabled;
@@ -81,7 +83,30 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
 
         public void Log(IDictionary<string, string> fields)
         {
-            ReportEvent(fields);
+            if (AllEnabled)
+            {
+                ReportEvent(fields);
+            }
+            else if (DebugEnabled && string.Equals(fields["level"], Logger.DEBUG, StringComparison.CurrentCultureIgnoreCase))
+            {
+                ReportEvent(fields);
+            }
+            else if (InfoEnabled && string.Equals(fields["level"], Logger.INFO, StringComparison.CurrentCultureIgnoreCase))
+            {
+                ReportEvent(fields);
+            }
+            else if (WarnEnabled && string.Equals(fields["level"], Logger.WARN, StringComparison.CurrentCultureIgnoreCase))
+            {
+                ReportEvent(fields);
+            }
+            else if (ErrorEnabled && string.Equals(fields["level"], Logger.ERROR, StringComparison.CurrentCultureIgnoreCase))
+            {
+                ReportEvent(fields);
+            }
+            else if (FatalEnabled && string.Equals(fields["level"], Logger.FATAL, StringComparison.CurrentCultureIgnoreCase))
+            {
+                ReportEvent(fields);
+            }
         }
 
         protected override bool PostEvent(object data)

--- a/GuaranteedRate.Sextant/Logging/ILogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/ILogAppender.cs
@@ -9,6 +9,7 @@ namespace GuaranteedRate.Sextant.Logging
     {
         void Log(IDictionary<string, string> fields);
         void AddTag(string tag);
+        bool AllEnabled { get; }
         bool DebugEnabled { get; }
         bool InfoEnabled { get; }
         bool WarnEnabled { get; }

--- a/GuaranteedRate.Sextant/Logging/Logger.cs
+++ b/GuaranteedRate.Sextant/Logging/Logger.cs
@@ -13,11 +13,11 @@ namespace GuaranteedRate.Sextant.Logging
         private static volatile IList<ILogAppender> _reporters = new List<ILogAppender>();
         private static readonly object syncRoot = new Object();
 
-        private const string ERROR = "ERROR";
-        private const string WARN = "WARN";
-        private const string INFO = "INFO";
-        private const string DEBUG = "DEBUG";
-        private const string FATAL = "FATAL";
+        public const string ERROR = "ERROR";
+        public const string WARN = "WARN";
+        public const string INFO = "INFO";
+        public const string DEBUG = "DEBUG";
+        public const string FATAL = "FATAL";
 
         public static void Setup(IEncompassConfig config)
         {

--- a/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
@@ -13,6 +13,7 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
 
         protected override string Name { get; } = typeof(LogglyLogAppender).Name;
         private static ISet<string> _tags;
+        public bool AllEnabled { get; set; }
         public bool ErrorEnabled { get; set; }
         public bool WarnEnabled { get; set; }
         public bool InfoEnabled { get; set; }
@@ -76,6 +77,7 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
             var debugEnabled = config.GetValue(LOGGLY_DEBUG, false);
             var fatalEnabled = config.GetValue(LOGGLY_FATAL, false);
 
+            AllEnabled = allEnabled;
             ErrorEnabled = allEnabled || errorEnabled;
             WarnEnabled = allEnabled || warnEnabled;
             InfoEnabled = allEnabled || infoEnabled;
@@ -117,7 +119,30 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
 
         public void Log(IDictionary<string, string> fields)
         {
-            ReportEvent(fields);
+            if (AllEnabled)
+            {
+                ReportEvent(fields);
+            }
+            else if (DebugEnabled && string.Equals(fields["level"], Logger.DEBUG, StringComparison.CurrentCultureIgnoreCase))
+            {
+                ReportEvent(fields);
+            }
+            else if (InfoEnabled && string.Equals(fields["level"], Logger.INFO, StringComparison.CurrentCultureIgnoreCase))
+            {
+                ReportEvent(fields);
+            }
+            else if (WarnEnabled && string.Equals(fields["level"], Logger.WARN, StringComparison.CurrentCultureIgnoreCase))
+            {
+                ReportEvent(fields);
+            }
+            else if (ErrorEnabled && string.Equals(fields["level"], Logger.ERROR, StringComparison.CurrentCultureIgnoreCase))
+            {
+                ReportEvent(fields);
+            }
+            else if (FatalEnabled && string.Equals(fields["level"], Logger.FATAL, StringComparison.CurrentCultureIgnoreCase))
+            {
+                ReportEvent(fields);
+            }
         }
     }
 }

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.2.6")]
-[assembly: AssemblyFileVersion("17.2.2.6")]
+[assembly: AssemblyVersion("17.2.2.7")]
+[assembly: AssemblyFileVersion("17.2.2.7")]


### PR DESCRIPTION
## v17.2.2.7 / 2017 Aug 28
* **Fix** - Fix regression that prevented loggers from filtering logs based on configured log level tolerance
 
```csharp
[GuaranteedRate.Sextant "17.2.2.7"]
```