### PR TITLE
automatic configuration of the ConsoleLogAppender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * **Add** - Added support for automatic configuration of the `ConsoleLogAppender` when utilizing `Logger.Setup()`
  
 ```csharp
-[GuaranteedRate.Sextant "17.2.2.7"]
+[GuaranteedRate.Sextant "17.2.2.8"]
 ```
 
 ## v17.2.2.7 / 2017 Aug 28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v17.2.2.8 / 2017 Aug 28
+* **Add** - Added support for automatic configuration of the `ConsoleLogAppender` when utilizing `Logger.Setup()`
+ 
+```csharp
+[GuaranteedRate.Sextant "17.2.2.7"]
+```
+
 ## v17.2.2.7 / 2017 Aug 28
 * **Fix** - Fix regression that prevented loggers from filtering logs based on configured log level tolerance
  

--- a/GuaranteedRate.Sextant/Logging/ConsoleLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/ConsoleLogAppender.cs
@@ -18,7 +18,8 @@ namespace GuaranteedRate.Sextant.Logging
         public bool FatalEnabled { get; private set; }
 
         #region config mappings
-        
+
+        public static string CONSOLE_ENABLED = "ConsoleLogAppender.Enabled";
         public static string CONSOLE_ALL = "ConsoleLogAppender.All.Enabled";
         public static string CONSOLE_ERROR = "ConsoleLogAppender.Error.Enabled";
         public static string CONSOLE_WARN = "ConsoleLogAppender.Warn.Enabled";
@@ -56,23 +57,23 @@ namespace GuaranteedRate.Sextant.Logging
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            else if (DebugEnabled && string.Equals(fields["level"], Logger.DEBUG, StringComparison.CurrentCultureIgnoreCase))
+            else if (DebugEnabled && string.Equals(fields[Logger.LEVEL], Logger.DEBUG, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            else if (InfoEnabled && string.Equals(fields["level"], Logger.INFO, StringComparison.CurrentCultureIgnoreCase))
+            else if (InfoEnabled && string.Equals(fields[Logger.LEVEL], Logger.INFO, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            else if (WarnEnabled && string.Equals(fields["level"], Logger.WARN, StringComparison.CurrentCultureIgnoreCase))
+            else if (WarnEnabled && string.Equals(fields[Logger.LEVEL], Logger.WARN, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            else if (ErrorEnabled && string.Equals(fields["level"], Logger.ERROR, StringComparison.CurrentCultureIgnoreCase))
+            else if (ErrorEnabled && string.Equals(fields[Logger.LEVEL], Logger.ERROR, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            else if (FatalEnabled && string.Equals(fields["level"], Logger.FATAL, StringComparison.CurrentCultureIgnoreCase))
+            else if (FatalEnabled && string.Equals(fields[Logger.LEVEL], Logger.FATAL, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }

--- a/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
@@ -87,23 +87,23 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
             {
                 ReportEvent(fields);
             }
-            else if (DebugEnabled && string.Equals(fields["level"], Logger.DEBUG, StringComparison.CurrentCultureIgnoreCase))
+            else if (DebugEnabled && string.Equals(fields[Logger.LEVEL], Logger.DEBUG, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (InfoEnabled && string.Equals(fields["level"], Logger.INFO, StringComparison.CurrentCultureIgnoreCase))
+            else if (InfoEnabled && string.Equals(fields[Logger.LEVEL], Logger.INFO, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (WarnEnabled && string.Equals(fields["level"], Logger.WARN, StringComparison.CurrentCultureIgnoreCase))
+            else if (WarnEnabled && string.Equals(fields[Logger.LEVEL], Logger.WARN, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (ErrorEnabled && string.Equals(fields["level"], Logger.ERROR, StringComparison.CurrentCultureIgnoreCase))
+            else if (ErrorEnabled && string.Equals(fields[Logger.LEVEL], Logger.ERROR, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (FatalEnabled && string.Equals(fields["level"], Logger.FATAL, StringComparison.CurrentCultureIgnoreCase))
+            else if (FatalEnabled && string.Equals(fields[Logger.LEVEL], Logger.FATAL, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }

--- a/GuaranteedRate.Sextant/Logging/Logger.cs
+++ b/GuaranteedRate.Sextant/Logging/Logger.cs
@@ -13,6 +13,7 @@ namespace GuaranteedRate.Sextant.Logging
         private static volatile IList<ILogAppender> _reporters = new List<ILogAppender>();
         private static readonly object syncRoot = new Object();
 
+        public const string LEVEL = "level";
         public const string ERROR = "ERROR";
         public const string WARN = "WARN";
         public const string INFO = "INFO";
@@ -31,6 +32,12 @@ namespace GuaranteedRate.Sextant.Logging
             if (elasticSearchEnabled)
             {
                 AddAppender(new ElasticsearchLogAppender(config));
+            }
+
+            var consoleEnabled = config.GetValue(ConsoleLogAppender.CONSOLE_ENABLED, false);
+            if (consoleEnabled)
+            {
+                AddAppender(new ConsoleLogAppender(config));
             }
         }
 
@@ -76,7 +83,7 @@ namespace GuaranteedRate.Sextant.Logging
         private static IDictionary<string, string> PopulateEvent(string loggerName, string level, string message)
         {
             IDictionary<string, string> fields = new ConcurrentDictionary<string, string>();
-            fields.Add("level", level);
+            fields.Add(LEVEL, level);
             fields.Add("timestamp", DateTime.Now.ToString("MM/dd/yyyyTHH:mm:ss.fffzzz"));
             fields.Add("hostname", System.Environment.MachineName);
             fields.Add("process", Process.GetCurrentProcess().ProcessName);
@@ -116,9 +123,9 @@ namespace GuaranteedRate.Sextant.Logging
             {
                 fields.Add("logger", loggerName);
             }
-            if (!fields.ContainsKey("level"))
+            if (!fields.ContainsKey(LEVEL))
             {
-                fields.Add("level", level);
+                fields.Add(LEVEL, level);
             }
             Log(fields);
         }

--- a/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
@@ -123,23 +123,23 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
             {
                 ReportEvent(fields);
             }
-            else if (DebugEnabled && string.Equals(fields["level"], Logger.DEBUG, StringComparison.CurrentCultureIgnoreCase))
+            else if (DebugEnabled && string.Equals(fields[Logger.LEVEL], Logger.DEBUG, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (InfoEnabled && string.Equals(fields["level"], Logger.INFO, StringComparison.CurrentCultureIgnoreCase))
+            else if (InfoEnabled && string.Equals(fields[Logger.LEVEL], Logger.INFO, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (WarnEnabled && string.Equals(fields["level"], Logger.WARN, StringComparison.CurrentCultureIgnoreCase))
+            else if (WarnEnabled && string.Equals(fields[Logger.LEVEL], Logger.WARN, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (ErrorEnabled && string.Equals(fields["level"], Logger.ERROR, StringComparison.CurrentCultureIgnoreCase))
+            else if (ErrorEnabled && string.Equals(fields[Logger.LEVEL], Logger.ERROR, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (FatalEnabled && string.Equals(fields["level"], Logger.FATAL, StringComparison.CurrentCultureIgnoreCase))
+            else if (FatalEnabled && string.Equals(fields[Logger.LEVEL], Logger.FATAL, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.2.7")]
-[assembly: AssemblyFileVersion("17.2.2.7")]
+[assembly: AssemblyVersion("17.2.2.8")]
+[assembly: AssemblyFileVersion("17.2.2.8")]

--- a/LoggingTestRig/Program.cs
+++ b/LoggingTestRig/Program.cs
@@ -18,15 +18,18 @@ namespace LoggingTestRig
         {
             var config = new JsonEncompassConfig();
             config.Init(System.IO.File.ReadAllText("../../SextantConfigTest.json"));
-                
-            var console = new ConsoleLogAppender(config);
+            
+            //manually set appenders    
+            //var console = new ConsoleLogAppender(config);
+            //var loggly = new LogglyLogAppender(config);
+            //var elasticSearch = new ElasticsearchLogAppender(config);
+            //Logger.AddAppender(console);
+            //Logger.AddAppender(loggly);
+            //Logger.AddAppender(elasticSearch);
 
-            var loggly = new LogglyLogAppender(config);
-            var elasticSearch = new ElasticsearchLogAppender(config);
+            //automatically set appenders
+            Logger.Setup(config);
 
-            Logger.AddAppender(console);
-            Logger.AddAppender(loggly);
-            Logger.AddAppender(elasticSearch);
             Logger.AddTag("runtime-tag");
 
             Logger.Debug("SextantTestRig", "Test debug message");


### PR DESCRIPTION
## v17.2.2.8 / 2017 Aug 28
* **Add** - Added support for automatic configuration of the `ConsoleLogAppender` when utilizing `Logger.Setup()`
 
```csharp
[GuaranteedRate.Sextant "17.2.2.8"]
```