### PR TITLE
update naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v17.2.2.9 / 2017 Aug 29
+* **Update** - Update Logger level naming convention to suffix `_LEVEL` so as to make IDE typeahead more pleasant
+ 
+```csharp
+[GuaranteedRate.Sextant "17.2.2.9"]
+```
+
 ## v17.2.2.8 / 2017 Aug 28
 * **Add** - Added support for automatic configuration of the `ConsoleLogAppender` when utilizing `Logger.Setup()`
  

--- a/GuaranteedRate.Sextant/Logging/ConsoleLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/ConsoleLogAppender.cs
@@ -57,23 +57,23 @@ namespace GuaranteedRate.Sextant.Logging
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            else if (DebugEnabled && string.Equals(fields[Logger.LEVEL], Logger.DEBUG, StringComparison.CurrentCultureIgnoreCase))
+            else if (DebugEnabled && string.Equals(fields[Logger.LEVEL], Logger.DEBUG_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            else if (InfoEnabled && string.Equals(fields[Logger.LEVEL], Logger.INFO, StringComparison.CurrentCultureIgnoreCase))
+            else if (InfoEnabled && string.Equals(fields[Logger.LEVEL], Logger.INFO_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            else if (WarnEnabled && string.Equals(fields[Logger.LEVEL], Logger.WARN, StringComparison.CurrentCultureIgnoreCase))
+            else if (WarnEnabled && string.Equals(fields[Logger.LEVEL], Logger.WARN_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            else if (ErrorEnabled && string.Equals(fields[Logger.LEVEL], Logger.ERROR, StringComparison.CurrentCultureIgnoreCase))
+            else if (ErrorEnabled && string.Equals(fields[Logger.LEVEL], Logger.ERROR_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }
-            else if (FatalEnabled && string.Equals(fields[Logger.LEVEL], Logger.FATAL, StringComparison.CurrentCultureIgnoreCase))
+            else if (FatalEnabled && string.Equals(fields[Logger.LEVEL], Logger.FATAL_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 Console.WriteLine(fields.Values.Aggregate((a, b) => $"{a}, {b}"));
             }

--- a/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
@@ -87,23 +87,23 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
             {
                 ReportEvent(fields);
             }
-            else if (DebugEnabled && string.Equals(fields[Logger.LEVEL], Logger.DEBUG, StringComparison.CurrentCultureIgnoreCase))
+            else if (DebugEnabled && string.Equals(fields[Logger.LEVEL], Logger.DEBUG_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (InfoEnabled && string.Equals(fields[Logger.LEVEL], Logger.INFO, StringComparison.CurrentCultureIgnoreCase))
+            else if (InfoEnabled && string.Equals(fields[Logger.LEVEL], Logger.INFO_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (WarnEnabled && string.Equals(fields[Logger.LEVEL], Logger.WARN, StringComparison.CurrentCultureIgnoreCase))
+            else if (WarnEnabled && string.Equals(fields[Logger.LEVEL], Logger.WARN_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (ErrorEnabled && string.Equals(fields[Logger.LEVEL], Logger.ERROR, StringComparison.CurrentCultureIgnoreCase))
+            else if (ErrorEnabled && string.Equals(fields[Logger.LEVEL], Logger.ERROR_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (FatalEnabled && string.Equals(fields[Logger.LEVEL], Logger.FATAL, StringComparison.CurrentCultureIgnoreCase))
+            else if (FatalEnabled && string.Equals(fields[Logger.LEVEL], Logger.FATAL_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }

--- a/GuaranteedRate.Sextant/Logging/Logger.cs
+++ b/GuaranteedRate.Sextant/Logging/Logger.cs
@@ -14,11 +14,11 @@ namespace GuaranteedRate.Sextant.Logging
         private static readonly object syncRoot = new Object();
 
         public const string LEVEL = "level";
-        public const string ERROR = "ERROR";
-        public const string WARN = "WARN";
-        public const string INFO = "INFO";
-        public const string DEBUG = "DEBUG";
-        public const string FATAL = "FATAL";
+        public const string ERROR_LEVEL = "ERROR";
+        public const string WARN_LEVEL = "WARN";
+        public const string INFO_LEVEL = "INFO";
+        public const string DEBUG_LEVEL = "DEBUG";
+        public const string FATAL_LEVEL = "FATAL";
 
         public static void Setup(IEncompassConfig config)
         {
@@ -94,27 +94,27 @@ namespace GuaranteedRate.Sextant.Logging
 
         public static void Debug(string logger, string message)
         {
-            Log(PopulateEvent(logger, DEBUG, message));
+            Log(PopulateEvent(logger, DEBUG_LEVEL, message));
         }
 
         public static void Error(string logger, string message)
         {
-            Log(PopulateEvent(logger, ERROR, message));
+            Log(PopulateEvent(logger, ERROR_LEVEL, message));
         }
 
         public static void Fatal(string logger, string message)
         {
-            Log(PopulateEvent(logger, FATAL, message));
+            Log(PopulateEvent(logger, FATAL_LEVEL, message));
         }
 
         public static void Info(string logger, string message)
         {
-            Log(PopulateEvent(logger, INFO, message));
+            Log(PopulateEvent(logger, INFO_LEVEL, message));
         }
 
         public static void Warn(string logger, string message)
         {
-            Log(PopulateEvent(logger, WARN, message));
+            Log(PopulateEvent(logger, WARN_LEVEL, message));
         }
 
         public static void Log(IDictionary<string, string> fields, string loggerName, string level)

--- a/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Loggly/LogglyLogAppender.cs
@@ -123,23 +123,23 @@ namespace GuaranteedRate.Sextant.Logging.Loggly
             {
                 ReportEvent(fields);
             }
-            else if (DebugEnabled && string.Equals(fields[Logger.LEVEL], Logger.DEBUG, StringComparison.CurrentCultureIgnoreCase))
+            else if (DebugEnabled && string.Equals(fields[Logger.LEVEL], Logger.DEBUG_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (InfoEnabled && string.Equals(fields[Logger.LEVEL], Logger.INFO, StringComparison.CurrentCultureIgnoreCase))
+            else if (InfoEnabled && string.Equals(fields[Logger.LEVEL], Logger.INFO_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (WarnEnabled && string.Equals(fields[Logger.LEVEL], Logger.WARN, StringComparison.CurrentCultureIgnoreCase))
+            else if (WarnEnabled && string.Equals(fields[Logger.LEVEL], Logger.WARN_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (ErrorEnabled && string.Equals(fields[Logger.LEVEL], Logger.ERROR, StringComparison.CurrentCultureIgnoreCase))
+            else if (ErrorEnabled && string.Equals(fields[Logger.LEVEL], Logger.ERROR_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }
-            else if (FatalEnabled && string.Equals(fields[Logger.LEVEL], Logger.FATAL, StringComparison.CurrentCultureIgnoreCase))
+            else if (FatalEnabled && string.Equals(fields[Logger.LEVEL], Logger.FATAL_LEVEL, StringComparison.CurrentCultureIgnoreCase))
             {
                 ReportEvent(fields);
             }

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.2.8")]
-[assembly: AssemblyFileVersion("17.2.2.8")]
+[assembly: AssemblyVersion("17.2.2.9")]
+[assembly: AssemblyFileVersion("17.2.2.9")]


### PR DESCRIPTION
## v17.2.2.9 / 2017 Aug 29
* **Update** - Update Logger level naming convention to suffix `_LEVEL` so as to make IDE typeahead more pleasant
 
```csharp
[GuaranteedRate.Sextant "17.2.2.9"]
```