### PR TITLE
Fix loggly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v17.2.2.14 / 2017 Sep 05
+* **Fix** - Forcing `AsyncEventReporter` to use `WebRequest` under the hood as `HttpClient` will cause deadlocks in 
+systems with asynchronous entry points.
+
+```csharp
+[GuaranteedRate.Sextant "17.2.2.14"]
+```
+
 ## v17.2.2.13 / 2017 Sep 05
 * **Fix** - Do not lock the log statement in `Logger.cs`
 

--- a/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
+++ b/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
@@ -166,10 +166,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/GuaranteedRate.Sextant/Metrics/Graphite/GraphiteReporter.cs
+++ b/GuaranteedRate.Sextant/Metrics/Graphite/GraphiteReporter.cs
@@ -107,10 +107,8 @@ namespace GuaranteedRate.Sextant.Metrics.Graphite
                     _client.Close();
                 }
             }
-
-            Client = null;
+            
             _client = null;
-
             _disposedValue = true;
         }
 

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.2.13")]
-[assembly: AssemblyFileVersion("17.2.2.13")]
+[assembly: AssemblyVersion("17.2.2.14")]
+[assembly: AssemblyFileVersion("17.2.2.14")]

--- a/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
@@ -5,10 +5,10 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Formatting;
 using System.Threading;
 using System.Threading.Tasks;
 using GuaranteedRate.Sextant.Logging;
+using Newtonsoft.Json;
 
 namespace GuaranteedRate.Sextant.WebClients
 {
@@ -17,6 +17,7 @@ namespace GuaranteedRate.Sextant.WebClients
      * creates a worker task to process messages from the queue in a separate thead.
      * 
      */
+
     public class AsyncEventReporter : IDisposable, IEventReporter
     {
         /// <summary>
@@ -33,19 +34,19 @@ namespace GuaranteedRate.Sextant.WebClients
             HttpStatusCode.NoContent,
             HttpStatusCode.OK
         };
-        
+
         private readonly BlockingCollection<object> _eventQueue;
         private readonly int _retries;
         private string _url;
-
+        public string ContentType { get; set; }
         protected const int DEFAULT_QUEUE_SIZE = 1000;
         protected const int DEFAULT_RETRIES = 3;
 
-        protected virtual string Name { get; } = typeof(AsyncEventReporter).Name;
+        protected virtual string Name { get; } = typeof (AsyncEventReporter).Name;
         private volatile bool _finished;
 
         protected HttpClient Client { get; set; }
-        
+
         public AsyncEventReporter(string url, int queueSize = DEFAULT_QUEUE_SIZE, int retries = DEFAULT_RETRIES)
         {
             if (string.IsNullOrEmpty(url))
@@ -71,7 +72,7 @@ namespace GuaranteedRate.Sextant.WebClients
         protected void CreateClient(string url)
         {
             _url = url;
-            Client = new HttpClient();  
+            Client = new HttpClient();
         }
 
         private void Init()
@@ -83,7 +84,7 @@ namespace GuaranteedRate.Sextant.WebClients
              * https://msdn.microsoft.com/en-us/library/dd997371(v=vs.110).aspx
              */
             // A simple blocking consumer with no cancellation.
-            
+
             Task.Run(() =>
             {
                 while (!_eventQueue.IsCompleted)
@@ -147,21 +148,62 @@ namespace GuaranteedRate.Sextant.WebClients
             return true;
         }
 
-        protected virtual bool PostEvent(object data)
+        protected virtual void ExtraSetup(WebRequest webRequest)
+        {
+        }
+
+        protected virtual bool PostEvent(object formattedData)
         {
             try
             {
-                var content = new ObjectContent<object>(data, new JsonMediaTypeFormatter());
-                var response = Client.PostAsync(_url, content).Result;  // Blocking call!
+                /**
+                 * According to documentation, .NET will reuse connection but not WebRequest object
+                 */
+                WebRequest webRequest = WebRequest.Create(_url);
+                if (webRequest != null)
+                {
+                    webRequest.Method = "POST";
+                    webRequest.Timeout = 45000;
+                    webRequest.ContentType = ContentType;
+                    ExtraSetup(webRequest);
+
+                    var stringFormattedData = JsonConvert.SerializeObject(formattedData);
+
+                    using (Stream stream = webRequest.GetRequestStream())
+                    {
+                        using (System.IO.StreamWriter sw = new System.IO.StreamWriter(stream))
+                            sw.Write(stringFormattedData);
+                    }
+
+                    using (System.IO.Stream s = webRequest.GetResponse().GetResponseStream())
+                    {
+                        using (System.IO.StreamReader sr = new System.IO.StreamReader(s))
+                        {
+                            var jsonResponse = sr.ReadToEnd();
+
+                            HttpWebResponse response = webRequest.GetResponse() as HttpWebResponse;
+                            if (response != null)
+                            {
+                                if (!SUCCESS_CODES.Contains(response.StatusCode))
+                                {
+                                    Logger.Warn(this.GetType().Name.ToString(),
+                                        "Webservice at " + _url + " returned status code:" + response.StatusCode);
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    Logger.Warn(this.GetType().Name.ToString(), "WebService url invalid. url=" + _url);
+                }
             }
-            catch (ApiException ex)
+            catch (Exception ex)
             {
-                var error =
-                    $"The following request returned a {ex.StackTrace} status code, resource endpoint: {Client.BaseAddress} model: {ex.Message}. Response {ex.Response}";
-                Logger.Warn(Name, error);
+                Logger.Error(this.GetType().Name.ToString(), "Log by Post to Service failed: " + ex.ToString());
                 return false;
             }
-
             return true;
         }
 

--- a/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
@@ -146,8 +146,14 @@ namespace GuaranteedRate.Sextant.WebClients
             return true;
         }
 
+        /// <summary>
+        /// Any additional actions that need to be applied to the WebRequest object
+        /// prior to being processed by PostEvent
+        /// </summary>
+        /// <param name="webRequest"></param>
         protected virtual void ExtraSetup(WebRequest webRequest)
         {
+
         }
 
         protected virtual bool PostEvent(object formattedData)

--- a/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
@@ -38,7 +38,7 @@ namespace GuaranteedRate.Sextant.WebClients
         private readonly BlockingCollection<object> _eventQueue;
         private readonly int _retries;
         private string _url;
-        public string ContentType { get; set; }
+        public string ContentType { get; set; } = "application/json";
         protected const int DEFAULT_QUEUE_SIZE = 1000;
         protected const int DEFAULT_RETRIES = 3;
 

--- a/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
@@ -44,8 +44,7 @@ namespace GuaranteedRate.Sextant.WebClients
 
         protected virtual string Name { get; } = typeof (AsyncEventReporter).Name;
         private volatile bool _finished;
-
-        protected HttpClient Client { get; set; }
+        
 
         public AsyncEventReporter(string url, int queueSize = DEFAULT_QUEUE_SIZE, int retries = DEFAULT_RETRIES)
         {
@@ -72,7 +71,6 @@ namespace GuaranteedRate.Sextant.WebClients
         protected void CreateClient(string url)
         {
             _url = url;
-            Client = new HttpClient();
         }
 
         private void Init()
@@ -218,8 +216,6 @@ namespace GuaranteedRate.Sextant.WebClients
                     Shutdown();
                 }
             }
-
-            Client = null;
 
             disposedValue = true;
         }

--- a/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
@@ -184,8 +184,7 @@ namespace GuaranteedRate.Sextant.WebClients
                             {
                                 if (!SUCCESS_CODES.Contains(response.StatusCode))
                                 {
-                                    Logger.Warn(this.GetType().Name.ToString(),
-                                        "Webservice at " + _url + " returned status code:" + response.StatusCode);
+                                    Logger.Warn(Name, $"Webservice at {_url} returned status code: {response.StatusCode}");
                                     return false;
                                 }
                             }
@@ -194,12 +193,12 @@ namespace GuaranteedRate.Sextant.WebClients
                 }
                 else
                 {
-                    Logger.Warn(this.GetType().Name.ToString(), "WebService url invalid. url=" + _url);
+                    Logger.Warn(Name, $"WebService url invalid. url={_url}");
                 }
             }
             catch (Exception ex)
             {
-                Logger.Error(this.GetType().Name.ToString(), "Log by Post to Service failed: " + ex.ToString());
+                Logger.Error(Name, $"Log by Post to Service failed: {ex}");
                 return false;
             }
             return true;

--- a/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
@@ -41,7 +41,7 @@ namespace GuaranteedRate.Sextant.WebClients
         public string ContentType { get; set; } = "application/json";
         protected const int DEFAULT_QUEUE_SIZE = 1000;
         protected const int DEFAULT_RETRIES = 3;
-
+        protected int DefaultTimeout = 45000;
         protected virtual string Name { get; } = typeof (AsyncEventReporter).Name;
         private volatile bool _finished;
         
@@ -161,7 +161,7 @@ namespace GuaranteedRate.Sextant.WebClients
                 if (webRequest != null)
                 {
                     webRequest.Method = "POST";
-                    webRequest.Timeout = 45000;
+                    webRequest.Timeout = DefaultTimeout;
                     webRequest.ContentType = ContentType;
                     ExtraSetup(webRequest);
 

--- a/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
@@ -37,16 +37,18 @@ namespace GuaranteedRate.Sextant.WebClients
 
         private readonly BlockingCollection<object> _eventQueue;
         private readonly int _retries;
+        private readonly int _timeout;
         private string _url;
         public string ContentType { get; set; } = "application/json";
         protected const int DEFAULT_QUEUE_SIZE = 1000;
         protected const int DEFAULT_RETRIES = 3;
-        protected int DefaultTimeout = 45000;
+        protected const int DEFAULT_TIMEOUT = 45000;
+        
         protected virtual string Name { get; } = typeof (AsyncEventReporter).Name;
         private volatile bool _finished;
         
 
-        public AsyncEventReporter(string url, int queueSize = DEFAULT_QUEUE_SIZE, int retries = DEFAULT_RETRIES)
+        public AsyncEventReporter(string url, int queueSize = DEFAULT_QUEUE_SIZE, int retries = DEFAULT_RETRIES, int timeout = DEFAULT_TIMEOUT)
         {
             if (string.IsNullOrEmpty(url))
             {
@@ -55,15 +57,17 @@ namespace GuaranteedRate.Sextant.WebClients
 
             _eventQueue = new BlockingCollection<object>(new ConcurrentQueue<object>(), queueSize);
             _retries = retries;
+            _timeout = timeout;
             CreateClient(url);
 
             Init();
         }
 
-        public AsyncEventReporter(int queueSize = DEFAULT_QUEUE_SIZE, int retries = DEFAULT_RETRIES)
+        public AsyncEventReporter(int queueSize = DEFAULT_QUEUE_SIZE, int retries = DEFAULT_RETRIES, int timeout = DEFAULT_TIMEOUT)
         {
             _eventQueue = new BlockingCollection<object>(new ConcurrentQueue<object>(), queueSize);
             _retries = retries;
+            _timeout = timeout;
 
             Init();
         }
@@ -167,7 +171,7 @@ namespace GuaranteedRate.Sextant.WebClients
                 if (webRequest != null)
                 {
                     webRequest.Method = "POST";
-                    webRequest.Timeout = DefaultTimeout;
+                    webRequest.Timeout = _timeout;
                     webRequest.ContentType = ContentType;
                     ExtraSetup(webRequest);
 

--- a/GuaranteedRate.Sextant/WebClients/SecureAsyncEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/SecureAsyncEventReporter.cs
@@ -1,20 +1,27 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http.Headers;
+using System.Net;
 
 namespace GuaranteedRate.Sextant.WebClients
 {
     public class SecureAsyncEventReporter : AsyncEventReporter
     {
+        private string _authorization { get; set; }
+
         public SecureAsyncEventReporter(string url, string authorization, int queueSize = DEFAULT_QUEUE_SIZE,
             int retries = DEFAULT_RETRIES)
             : base(url, queueSize, retries)
         {
             if (!string.IsNullOrEmpty(authorization))
             {
-                Client.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(authorization);
+                _authorization = authorization;
             }
         }
+
+        protected override void ExtraSetup(WebRequest webRequest)
+        {
+            webRequest.Headers.Add("Authorization:" + _authorization);
+        }       
     }
 }

--- a/GuaranteedRate.Sextant/packages.config
+++ b/GuaranteedRate.Sextant/packages.config
@@ -5,7 +5,6 @@
   <package id="Metrics.NET" version="0.5.3" targetFramework="net452" />
   <package id="Metrics.NET.Datadog" version="1.0.0" targetFramework="net452" />
   <package id="Metrics.NET.Graphite" version="0.5.0" targetFramework="net452" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="NEST" version="5.4.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
## v17.2.2.14 / 2017 Sep 05
* **Fix** - Forcing `AsyncEventReporter` to use `WebRequest` under the hood as `HttpClient` will cause deadlocks in systems with asynchronous entry points.

```csharp
[GuaranteedRate.Sextant "17.2.2.14"]
```