### PR TITLE
Fix timestamps for elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v17.2.2.16 / 2017 Sep 07
+* **Fix** - Now sending timestamps fully in UTC format
+* **Fix** - Fix `ElasticsearchLogAppender` to send timestamps in date format.  Previously we were sending dates as 
+a string which was preventing adequate date indexing
+
+```csharp
+[GuaranteedRate.Sextant "17.2.2.16"]
+```
+
 ## v17.2.2.15 / 2017 Sep 05
 * **Update** - Add the url of the failing service to the logs
 

--- a/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
+++ b/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
@@ -191,6 +191,7 @@
     <Compile Include="EncompassUtils\Reporting.cs" />
     <Compile Include="EncompassUtils\SessionUtils.cs" />
     <Compile Include="EncompassUtils\UserUtils.cs" />
+    <Compile Include="Logging\Elasticsearch\ElasticLogEvent.cs" />
     <Compile Include="Metrics\Graphite\GraphiteReporter.cs" />
     <Compile Include="Metrics\Graphite\StatsDGraphiteReport.cs" />
     <Compile Include="Metrics\IReporter.cs" />

--- a/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticLogEvent.cs
+++ b/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticLogEvent.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GuaranteedRate.Sextant.Logging.Elasticsearch
+{
+    public class ElasticLogEvent
+    {
+        public string loggerName { get; set; }
+        public string process { get; set; }
+        public string level { get; set; }
+        public DateTime timestamp { get; set; }
+        public string message { get; set; }
+        public string hostname { get; set; }
+    }
+}

--- a/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
@@ -126,9 +126,19 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
 
             fields["tags"] = JsonConvert.SerializeObject(_tags);
 
+            var logEvent = new ElasticLogEvent
+            {
+                loggerName = fields["loggerName"],
+                hostname = fields["hostname"],
+                timestamp = DateTime.Parse(fields["timestamp"]),
+                level = fields[Logger.LEVEL],
+                message = fields["message"],
+                process = fields["process"]
+            };
+
             try
             {
-                var response = _client.Index(fields, idx => idx.Index($"{loggerName}-{DateTime.UtcNow.ToString("yyyy.MM.dd")}"));
+                var response = _client.Index(logEvent, idx => idx.Index($"{loggerName}-{DateTime.UtcNow.ToString("yyyy.MM.dd")}"));
 
                 if (!response.IsValid)
                 {

--- a/GuaranteedRate.Sextant/Logging/Logger.cs
+++ b/GuaranteedRate.Sextant/Logging/Logger.cs
@@ -86,7 +86,7 @@ namespace GuaranteedRate.Sextant.Logging
         {
             IDictionary<string, string> fields = new ConcurrentDictionary<string, string>();
             fields.Add(LEVEL, level);
-            fields.Add("timestamp", DateTime.Now.ToString("MM/dd/yyyyTHH:mm:ss.fffzzz"));
+            fields.Add("timestamp", DateTime.UtcNow.ToString());
             fields.Add("hostname", System.Environment.MachineName);
             fields.Add("process", Process.GetCurrentProcess().ProcessName);
             fields.Add("loggerName", loggerName);

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.2.15")]
-[assembly: AssemblyFileVersion("17.2.2.15")]
+[assembly: AssemblyVersion("17.2.2.16")]
+[assembly: AssemblyFileVersion("17.2.2.16")]


### PR DESCRIPTION
## v17.2.2.16 / 2017 Sep 07
* **Fix** - Now sending timestamps fully in UTC format
* **Fix** - Fix `ElasticsearchLogAppender` to send timestamps in date format.  Previously we were sending dates as a string which was preventing adequate date indexing

```csharp
[GuaranteedRate.Sextant "17.2.2.16"]
```