### PR TITLE
default index name so we don't blow up elastic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v17.2.3.0 / 2017 Sep 26
+* **Fix** - Sensible default index name so we aren't creating lots of elasticsearch indexes named after every logger.  
+
+```csharp
+[GuaranteedRate.Sextant "17.2.3.0"]
+```
+
 ## v17.2.2.16 / 2017 Sep 07
 * **Fix** - Now sending timestamps fully in UTC format
 * **Fix** - Fix `ElasticsearchLogAppender` to send timestamps in date format.  Previously we were sending dates as 

--- a/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
+++ b/GuaranteedRate.Sextant/Logging/Elasticsearch/ElasticsearchLogAppender.cs
@@ -14,6 +14,7 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
         protected override string Name { get; } = typeof(ElasticsearchLogAppender).Name;
         private Uri _node;
         private ConnectionSettings _settings;
+        private string _indexName;
         private ElasticClient _client;
         private static ISet<string> _tags;
         public bool AllEnabled { get; set; }
@@ -36,6 +37,7 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
         public static string ELASTICSEARCH_DEBUG = "ElasticsearchLogAppender.Debug.Enabled";
         public static string ELASTICSEARCH_FATAL = "ElasticsearchLogAppender.Fatal.Enabled";
         public static string ELASTICSEARCH_TAGS = "ElasticsearchLogAppender.Tags";
+        public static string ELASTICSEARCH_INDEX_NAME = "ElasticsearchLogAppender.IndexName";
 
         #endregion
 
@@ -53,7 +55,7 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
             _node = new Uri(url);
             _settings = new ConnectionSettings(_node);
             _client = new ElasticClient(_settings);
-
+            _indexName = config.GetValue(ELASTICSEARCH_INDEX_NAME, "SextantLogger");
             var allEnabled = config.GetValue(ELASTICSEARCH_ALL, true);
             var errorEnabled = config.GetValue(ELASTICSEARCH_ERROR, true);
             var warnEnabled = config.GetValue(ELASTICSEARCH_WARN, true);
@@ -138,7 +140,7 @@ namespace GuaranteedRate.Sextant.Logging.Elasticsearch
 
             try
             {
-                var response = _client.Index(logEvent, idx => idx.Index($"{loggerName}-{DateTime.UtcNow.ToString("yyyy.MM.dd")}"));
+                var response = _client.Index(logEvent, idx => idx.Index($"{_indexName}-{DateTime.UtcNow.ToString("yyyy.MM.dd")}"));
 
                 if (!response.IsValid)
                 {

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.2.2.16")]
-[assembly: AssemblyFileVersion("17.2.2.16")]
+[assembly: AssemblyVersion("17.2.3.0")]
+[assembly: AssemblyFileVersion("17.2.3.0")]


### PR DESCRIPTION
setting the elasticsearch index name equal to the logger name does bad things.