### PR TITLE
Fix double log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v17.4.1.6 / 2017 Feb 20
+
+* **Fix**  - Fix double logging. 
+* **Fix**  - Fix field collission.
+
+```csharp
+[GuaranteedRate.Sextant "17.4.1.6"]
+```
+
 ## v17.4.1.5 / 2017 Feb 14
 
 * **Update**  - Ensure logs contain structured data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v17.4.1.6 / 2017 Feb 20
 
 * **Fix**  - Fix double logging. 
-* **Fix**  - Fix field collission.
+* **Fix**  - Fix field collision.
 
 ```csharp
 [GuaranteedRate.Sextant "17.4.1.6"]

--- a/GuaranteedRate.Sextant/Logging/Logger.cs
+++ b/GuaranteedRate.Sextant/Logging/Logger.cs
@@ -148,8 +148,6 @@ namespace GuaranteedRate.Sextant.Logging
 
         private static IDictionary<string, string> PopulateEvent(string loggerName, string message, IDictionary<string, string> fields = null)
         {
-            var tmpMsg = message;
-        
             if (fields == null)
             {
                 fields = new ConcurrentDictionary<string, string>();
@@ -157,15 +155,15 @@ namespace GuaranteedRate.Sextant.Logging
 
             if (fields.ContainsKey(MESSAGE_KEY) && string.IsNullOrEmpty(message))
             {
-                tmpMsg = fields[MESSAGE_KEY];
+                message = fields[MESSAGE_KEY];
             }
 
             fields.Remove(MESSAGE_KEY);
             fields.Remove(TIMESTAMP_KEY);
             fields.Remove(LOGGERNAME_KEY);
 
-            fields.Add(MESSAGE_KEY, tmpMsg);
-            fields.Add(TIMESTAMP_KEY, DateTime.UtcNow.ToString());
+            fields.Add(MESSAGE_KEY, message);
+            fields.Add(TIMESTAMP_KEY, DateTime.UtcNow.ToString(CultureInfo.InvariantCulture));
             fields.Add(LOGGERNAME_KEY, loggerName);
 
             foreach (var tt in _additionalTags)

--- a/GuaranteedRate.Sextant/Logging/Logger.cs
+++ b/GuaranteedRate.Sextant/Logging/Logger.cs
@@ -24,6 +24,9 @@ namespace GuaranteedRate.Sextant.Logging
         public const string INFO_LEVEL = "INFO";
         public const string DEBUG_LEVEL = "DEBUG";
         public const string FATAL_LEVEL = "FATAL";
+        private const string MESSAGE_KEY = "message";
+        private const string TIMESTAMP_KEY = "timestamp";
+        private const string LOGGERNAME_KEY = "loggerName";
         private static ConcurrentDictionary<string, string> _additionalTags;
 
         #region config mappings
@@ -145,13 +148,25 @@ namespace GuaranteedRate.Sextant.Logging
 
         private static IDictionary<string, string> PopulateEvent(string loggerName, string message, IDictionary<string, string> fields = null)
         {
+            var tmpMsg = message;
+        
             if (fields == null)
             {
                 fields = new ConcurrentDictionary<string, string>();
             }
-            fields.Add("message", message);
-            fields.Add("timestamp", DateTime.UtcNow.ToString());
-            fields.Add("loggerName", loggerName);
+
+            if (fields.ContainsKey(MESSAGE_KEY) && string.IsNullOrEmpty(message))
+            {
+                tmpMsg = fields[MESSAGE_KEY];
+            }
+
+            fields.Remove(MESSAGE_KEY);
+            fields.Remove(TIMESTAMP_KEY);
+            fields.Remove(LOGGERNAME_KEY);
+
+            fields.Add(MESSAGE_KEY, tmpMsg);
+            fields.Add(TIMESTAMP_KEY, DateTime.UtcNow.ToString());
+            fields.Add(LOGGERNAME_KEY, loggerName);
 
             foreach (var tt in _additionalTags)
             {

--- a/GuaranteedRate.Sextant/Logging/Logger.cs
+++ b/GuaranteedRate.Sextant/Logging/Logger.cs
@@ -297,18 +297,18 @@ namespace GuaranteedRate.Sextant.Logging
             if (configured)
             {
                 var lv = PrepLogValues(loggerName, "", fields);
-                switch (level.ToLowerInvariant())
+                switch (level.ToUpperInvariant())
                 {
-                    case "fatal":
+                    case FATAL_LEVEL:
                         Serilog.Log.Logger.Fatal(lv.Item1, lv.Item2);
                         break;
-                    case "error":
+                    case ERROR_LEVEL:
                         Serilog.Log.Logger.Error(lv.Item1, lv.Item2);
                         break;
-                    case "warn":
+                    case WARN_LEVEL:
                         Serilog.Log.Logger.Warning(lv.Item1, lv.Item2);
                         break;
-                    case "info":
+                    case INFO_LEVEL:
                         Serilog.Log.Logger.Information(lv.Item1, lv.Item2);
                         break;
                     default:

--- a/GuaranteedRate.Sextant/Logging/Logger.cs
+++ b/GuaranteedRate.Sextant/Logging/Logger.cs
@@ -86,7 +86,6 @@ namespace GuaranteedRate.Sextant.Logging
 
         #endregion
 
-
         public static void Setup(IEncompassConfig config, Dictionary<string, string> additionalTags = null)
         {
             LoggerConfiguration baseLogger = null;
@@ -144,11 +143,8 @@ namespace GuaranteedRate.Sextant.Logging
             }
         }
 
-
-
         private static IDictionary<string, string> PopulateEvent(string loggerName, string message, IDictionary<string, string> fields = null)
         {
-
             if (fields == null)
             {
                 fields = new ConcurrentDictionary<string, string>();
@@ -219,7 +215,6 @@ namespace GuaranteedRate.Sextant.Logging
 
         }
 
-
         private static Tuple<string, object[]> PrepLogValues(string logger, string message, IDictionary<string, string> fields = null)
         {
             var data = PopulateEvent(logger, message, fields);
@@ -284,11 +279,9 @@ namespace GuaranteedRate.Sextant.Logging
 
         public static void Log(IDictionary<string, string> fields, string loggerName, string level)
         {
-
             if (configured)
             {
                 var lv = PrepLogValues(loggerName, "", fields);
-                Serilog.Log.Logger.Error(lv.Item1, lv.Item2);
                 switch (level.ToLowerInvariant())
                 {
                     case "fatal":

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("17.4.1.5")]
-[assembly: AssemblyFileVersion("17.4.1.5")]
+[assembly: AssemblyVersion("17.4.1.6")]
+[assembly: AssemblyFileVersion("17.4.1.6")]


### PR DESCRIPTION
- Fix a double logging issue
- Remove default fields in PopulateEvent from entry fields to avoid dictionary key collision.
- Make use of constants in logging critical paths.
- Use InvariantCulture for DateTime, instead of the default CurrentCulture.