### PR TITLE
YBR-591: capture additional uw condition data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v18.2.0.1 / 2018 June 18
+
+* **Add**  - capture additional data about underwriting conditions into uw-conditions-metadata field
+
 ## v18.1.0.0 / 2018 March 4
 
 * **Update**  - Upgrade all projects to Encompass 18.1

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("18.2.0.0")]
-[assembly: AssemblyFileVersion("18.2.0.0")]
+[assembly: AssemblyVersion("18.2.1.0")]
+[assembly: AssemblyFileVersion("18.2.1.0")]


### PR DESCRIPTION
Currently, in Polaris, there are 15 fields for every condition named like Conditio.<attribute>.<Title> were attribute is in ("AddedBy" "AllowToClear" "Category" "ClearedBy" "Description" "DateCleared" "DateAdded"
    "IsCleared" "IsInternal" "IsReceived" "IsReviewed" "IsWaived" "PriorTo" "Status" "Title")
e.g. 
{….
    "Condition.Description.Audit_Review_-_Required": "Audit Required- File has been selected for Audit Review.  Underwriting will submit for Audit Review to AReview@GuaranteedRate.com once all conditions have been cleared.  Please allow up to 24 hours for review.",
    "Condition.DateAdded.Audit_Review_-_Required": "4/19/2018 12:00:00 AM",
….}
 
Unfortunately, this doesn’t include enough data to reproduce the order in which conditions are printed on in UW Approval PDF Report as implemented in UWConditionPrintingOverride [plugin](https://github.com/Guaranteed-Rate/Enc.Codebase.EncompassUWConditionPrintingOverride/blob/master/EncompassUWConditionPrintingOverride/UwConditionReport/ConditionBuilders/BaseConditionBuilder.cs#L158)

 
Specifically
•	There is no way to get Loan.Log.UnderwritingConditions[0].ForRole
•	DateAdded comes through as date-at-midnight where as Loan.Log.UnderwritingConditions[0].DateAdded includes date and time.
Both of these are required to get the order correct.
