### PR TITLE
[Sextant] Proposing a new `ILogger` interface and `SextantLogger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v18.4.0.1 / 2018 Dec 19
+
+* **Add** - New ILogger interface and SextantLogger implementation for supporting standard logging in form codebases to start with
+
+
 ## v18.4.0.0 / 2018 Dec 11
 
 * **Update** - Upgrade EncompassSDK.Complete 18.4 for Encompass Upgrade

--- a/GuaranteedRate.Sextant.Tests/GuaranteedRate.Sextant.Tests.csproj
+++ b/GuaranteedRate.Sextant.Tests/GuaranteedRate.Sextant.Tests.csproj
@@ -40,6 +40,9 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Client, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
       <HintPath>..\packages\EncompassSDK.Complete.18.4.0.7\lib\net45\Client.dll</HintPath>
     </Reference>
@@ -134,6 +137,9 @@
       <HintPath>..\packages\loggly-csharp-config.4.6.1.55\lib\net45\Loggly.Config.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.10.1\lib\net45\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\EncompassSDK.Complete.18.2.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -179,7 +185,14 @@
       <HintPath>..\packages\EncompassSDK.Complete.18.4.0.7\lib\net45\SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Razor.3.0.0\lib\net45\System.Web.Razor.dll</HintPath>
@@ -206,6 +219,7 @@
   <ItemGroup>
     <Compile Include="Configs\IniConfigTests.cs" />
     <Compile Include="Configs\JsonEncompassConfitTests.cs" />
+    <Compile Include="Logging\SextantLoggerUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Configs\WindowModel.cs" />
   </ItemGroup>
@@ -224,6 +238,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GuaranteedRate.Sextant.Integration.Core\GuaranteedRate.Sextant.Integration.Core.csproj">
+      <Project>{1C0A0D30-1FCE-4650-8B36-4611DA6C1546}</Project>
+      <Name>GuaranteedRate.Sextant.Integration.Core</Name>
+    </ProjectReference>
     <ProjectReference Include="..\GuaranteedRate.Sextant\GuaranteedRate.Sextant.csproj">
       <Project>{6388e4a7-456a-4363-9ac4-936f742ca63f}</Project>
       <Name>GuaranteedRate.Sextant</Name>

--- a/GuaranteedRate.Sextant.Tests/Logging/SextantLoggerUnitTests.cs
+++ b/GuaranteedRate.Sextant.Tests/Logging/SextantLoggerUnitTests.cs
@@ -1,0 +1,82 @@
+﻿using GuaranteedRate.Sextant.Config;
+using GuaranteedRate.Sextant.Integration.Core;
+using GuaranteedRate.Sextant.Logging;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace GuaranteedRate.Sextant.Tests.Logging
+{
+    [TestFixture]
+    public class SextantLoggerUnitTests
+    {
+        private IEncompassConfig _encompassConfig;
+        private string _loggerName = "SextantUnitTests";
+
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+            _encompassConfig = new IntegrationEncompassConfig();
+        }
+
+        [Test]
+        public void Constructor_with_config_only_returns_logger()
+        {
+            // act
+            var actual = new SextantLogger(_encompassConfig, _loggerName);
+
+            // assert
+            Assert.NotNull(actual);
+        }
+
+        [Test]
+        public void Constructor_with_client_context_returns_logger()
+        {
+            // act
+            var actual = new SextantLogger(_encompassConfig, _loggerName, "UnitTestClientID", "SextantLoggerUnitTests");
+
+            // assert
+            Assert.NotNull(actual);
+        }
+
+        [Test]
+        public void Constructor_with_tags_returns_logger()
+        {
+            // arrange
+            var additionalTags = new Dictionary<string, string>()
+            {
+                { "tag1", "value1" },
+                { "tag2", "value2" }
+            };
+
+            // act
+            var actual = new SextantLogger(_encompassConfig, _loggerName, additionalTags);
+
+            // assert
+            Assert.NotNull(actual);
+        }
+
+
+        [Test]
+        public void Sample_Logger_Info_mock()
+        {
+            // arrange
+            var loggerMock = new Mock<ILogger>();
+
+            var textToBeLogged = "Some text to log here";
+            var infoMessage = string.Empty;
+
+            loggerMock.Setup(x => x.Info(It.IsAny<string>())).Callback((string message) =>
+            {
+                infoMessage = message;
+            }).Verifiable();
+
+            // act
+            loggerMock.Object.Info(textToBeLogged);
+
+            // assert
+            Assert.AreEqual(textToBeLogged, infoMessage);
+        }
+
+    }
+}

--- a/GuaranteedRate.Sextant.Tests/packages.config
+++ b/GuaranteedRate.Sextant.Tests/packages.config
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
   <package id="EncompassSDK.Complete" version="18.4.0.7" targetFramework="net452" />
   <package id="loggly-csharp" version="4.6.1.55" targetFramework="net452" />
   <package id="loggly-csharp-config" version="4.6.1.55" targetFramework="net452" />
   <package id="Microsoft.AspNet.Razor" version="3.0.0" targetFramework="net452" />
+  <package id="Moq" version="4.10.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
   <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net452" />
@@ -14,4 +16,6 @@
   <package id="Serilog.Sinks.Loggly" version="5.3.0" targetFramework="net452" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net452" />
   <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net452" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net452" />
 </packages>

--- a/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
+++ b/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
@@ -228,7 +228,9 @@
     <Compile Include="EncompassUtils\Reporting.cs" />
     <Compile Include="EncompassUtils\SessionUtils.cs" />
     <Compile Include="EncompassUtils\UserUtils.cs" />
+    <Compile Include="Logging\ILogger.cs" />
     <Compile Include="Logging\SerilogHelpers.cs" />
+    <Compile Include="Logging\SextantLogger.cs" />
     <Compile Include="Metrics\Graphite\GraphiteReporter.cs" />
     <Compile Include="Metrics\Graphite\StatsDGraphiteReport.cs" />
     <Compile Include="Metrics\IReporter.cs" />

--- a/GuaranteedRate.Sextant/Logging/ILogger.cs
+++ b/GuaranteedRate.Sextant/Logging/ILogger.cs
@@ -1,0 +1,76 @@
+﻿using System;
+
+namespace GuaranteedRate.Sextant.Logging
+{
+    /// <summary>
+    /// Interface for standard logging implementations that also enables proper unit testing and future dependency injection, when required
+    /// </summary>
+    public interface ILogger
+    {
+
+        /// <summary>
+        /// Informations the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        void Info(string message);
+
+        /// <summary>
+        /// Informations the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        void Info(string message, Exception exception);
+
+        /// <summary>
+        /// Debugs the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        void Debug(string message);
+
+        /// <summary>
+        /// Debugs the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        void Debug(string message, Exception exception);
+
+        /// <summary>
+        /// Warnings the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        void Warning(string message);
+
+        /// <summary>
+        /// Warnings the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        void Warning(string message, Exception exception);
+
+        /// <summary>
+        /// Errors the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        void Error(string message);
+
+        /// <summary>
+        /// Errors the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        void Error(string message, Exception exception);
+
+        /// <summary>
+        /// Fatals the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        void Fatal(string message);
+
+        /// <summary>
+        /// Fatals the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        void Fatal(string message, Exception exception);
+    }
+}

--- a/GuaranteedRate.Sextant/Logging/SextantLogger.cs
+++ b/GuaranteedRate.Sextant/Logging/SextantLogger.cs
@@ -1,0 +1,209 @@
+﻿using GuaranteedRate.Sextant.Config;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace GuaranteedRate.Sextant.Logging
+{
+    /// <summary>
+    /// Sextant implementation for ILogger that wraps around the existing Logger class methods
+    /// </summary>
+    public class SextantLogger : ILogger
+    {
+        private readonly string _logglyName;
+
+        /// <summary>
+        /// Creates instance of SextantLogger without client context or additional tags
+        /// </summary>
+        /// <param name="config">Encompass configuration to use for Logger setup</param>
+        /// <param name="loggerName">Logger name for this instance</param>
+        public SextantLogger(IEncompassConfig config, string loggerName)
+        {
+            _logglyName = loggerName;
+
+            Setup(config, string.Empty, string.Empty);
+        }
+
+        /// <summary>
+        /// Creates instance of SextantLogger with the specified client and context
+        /// </summary>
+        /// <param name="config">Encompass configuration to use for Logger setup</param>
+        /// <param name="loggerName">Logger name for this instance</param>
+        public SextantLogger(IEncompassConfig config, string loggerName, string clientId, string context)
+        {
+            _logglyName = loggerName;
+
+            Setup(config, clientId, context);
+        }
+
+        /// <summary>
+        /// Creates instance of SextantLogger with the tags provided
+        /// </summary>
+        /// <param name="config">Encompass configuration to use for Logger setup</param>
+        /// <param name="loggerName">Logger name for this instance</param>
+        public SextantLogger(IEncompassConfig config, string loggerName, Dictionary<string, string> additionalTags)
+        {
+            _logglyName = loggerName;
+
+            Setup(config, additionalTags);
+        }
+
+        private void Setup(IEncompassConfig config, string clientId, string context)
+        {
+            var tags = new Dictionary<string, string>();
+
+            tags.Add("assembly", GetAssemblyNameSafely());
+            tags.Add("version", GetVersionSafely());
+            tags.Add("environment", config.GetValue("Encompass.Environment"));
+
+            if (!string.IsNullOrEmpty(context)) tags.Add("context", context);
+            if (!string.IsNullOrEmpty(clientId)) tags.Add("clientid", clientId);
+
+            Setup(config, tags);
+        }
+
+        private void Setup(IEncompassConfig config, Dictionary<string, string> additionalTags)
+        {
+            Logger.Setup(config, additionalTags);
+        }
+
+        /// <summary>
+        /// Debugs the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public void Debug(string message)
+        {
+            Logger.Debug(_logglyName, message);
+        }
+
+        /// <summary>
+        /// Debugs the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        public void Debug(string message, Exception exception)
+        {
+            Debug(Combine(message, exception));
+        }
+
+        /// <summary>
+        /// Informations the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public void Info(string message)
+        {
+            Logger.Info(_logglyName, message);
+        }
+
+        /// <summary>
+        /// Informations the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        public void Info(string message, Exception exception)
+        {
+            Info(Combine(message, exception));
+        }
+
+        /// <summary>
+        /// Warnings the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public void Warning(string message)
+        {
+            Logger.Warn(_logglyName, message);
+        }
+
+        /// <summary>
+        /// Warnings the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        public void Warning(string message, Exception exception)
+        {
+            Warning(Combine(message, exception));
+
+        }
+        /// <summary>
+        /// Errors the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public void Error(string message)
+        {
+            Logger.Error(_logglyName, message);
+        }
+
+        /// <summary>
+        /// Errors the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        public void Error(string message, Exception exception)
+        {
+            Error(Combine(message, exception));
+        }
+        /// <summary>
+        /// Fatals the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public void Fatal(string message)
+        {
+            Logger.Fatal(_logglyName, message);
+        }
+        /// <summary>
+        /// Fatals the specified message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        public void Fatal(string message, Exception exception)
+        {
+            Fatal(Combine(message, exception));
+        }
+
+        /// <summary>
+        /// Sextant doesn't support supplying the exception with the message, so we combine them into one string
+        /// to submit to the Sextant logger.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        private string Combine(string message, Exception exception)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine(message);
+            sb.AppendLine($"Exception: {exception.GetType().Name}");
+            sb.AppendLine(exception.Message);
+            sb.AppendLine(exception.StackTrace);
+            return sb.ToString();
+        }
+
+        private string GetVersionSafely()
+        {
+            string version;
+            try
+            {
+                version = Assembly.GetExecutingAssembly().FullName.Split(',')[1].Split('=')[1];
+            }
+            catch
+            {
+                version = "Unable to retrieve version";
+            }
+            return version;
+        }
+
+        private string GetAssemblyNameSafely()
+        {
+            string version;
+            try
+            {
+                version = Assembly.GetExecutingAssembly().FullName.Split(',')[0];
+            }
+            catch
+            {
+                version = "Unable to retrieve assembly name";
+            }
+            return version;
+        }
+
+    }
+}

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("18.4.0.0")]
-[assembly: AssemblyFileVersion("18.4.0.0")]
+[assembly: AssemblyVersion("18.4.0.1")]
+[assembly: AssemblyFileVersion("18.4.0.1")]

--- a/README.md
+++ b/README.md
@@ -108,6 +108,53 @@ Under the hood, we automatically add three tags:
 
 - An example usage of `Logger` in action can be found in [LoggingTestRig](LoggingTestRig/Program.cs)
 
+### ILogger
+
+**ILogger** is an interface that can be used for standard logging for form codebases among other places.  It can also be used in cases where dependency injection is required, and can be mocked for unit testing purposes.
+
+**SextantLogger** is an implementation of `ILogger` that wraps around the current `Logger` class for Loggly, and has constructors to be called directly in lieu of dependency injection support.
+
+Sample usage
+```csharp
+var config = new JsonEncompassConfig();
+config.Init(System.IO.File.ReadAllText("SextantConfigTest.json"));
+
+ILogger logger = new SextantLogger(config, "SextantTestRig");
+                
+logger.Debug("Test debug message");
+logger.Info("Test info message");
+logger.Warn("Test warn message");
+logger.Error("Test error message");
+logger.Fatal("Test fatal message");
+
+```
+
+The following is an example of how `ILogger` can be mocked in code that requires logging:
+
+```csharp
+[Test]
+public void Sample_Logger_Info_mock()
+{
+    // arrange
+    var loggerMock = new Mock<ILogger>();
+
+    var textToBeLogged = "Some text to log here";
+    var infoMessage = string.Empty;
+
+    loggerMock.Setup(x => x.Info(It.IsAny<string>())).Callback((string message) =>
+    {
+        infoMessage = message;
+    }).Verifiable();
+
+    // act
+    loggerMock.Object.Info(textToBeLogged);
+
+    // assert
+    Assert.AreEqual(textToBeLogged, infoMessage);
+}
+
+```
+
 ## Metrics tracking
 
 ### Metrics


### PR DESCRIPTION
Proposing a new `ILogger` interface and `SextantLogger` implementation for supporting standard logging and unit testing in form codebases.

[x] Unit tests pass?
[x] Version bumped?
[x] Changelog?
[x] Readme?