### PR TITLE
[NullLogger] New NullLogger implementation for ILogger interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v18.4.0.2 / 2018 Dec 24
+
+* **Add** - New `NullLogger` implementation of the `ILogger` interface for instances where configuration settings are not available.  As a result, log messages will be discarded.
+
+
 ## v18.4.0.1 / 2018 Dec 19
 
 * **Add** - New ILogger interface and SextantLogger implementation for supporting standard logging in form codebases to start with

--- a/GuaranteedRate.Sextant.Tests/GuaranteedRate.Sextant.Tests.csproj
+++ b/GuaranteedRate.Sextant.Tests/GuaranteedRate.Sextant.Tests.csproj
@@ -219,6 +219,7 @@
   <ItemGroup>
     <Compile Include="Configs\IniConfigTests.cs" />
     <Compile Include="Configs\JsonEncompassConfitTests.cs" />
+    <Compile Include="Logging\NullLoggerUnitTests.cs" />
     <Compile Include="Logging\SextantLoggerUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Configs\WindowModel.cs" />

--- a/GuaranteedRate.Sextant.Tests/Logging/NullLoggerUnitTests.cs
+++ b/GuaranteedRate.Sextant.Tests/Logging/NullLoggerUnitTests.cs
@@ -1,0 +1,54 @@
+﻿using GuaranteedRate.Sextant.Logging;
+using NUnit.Framework;
+
+namespace GuaranteedRate.Sextant.Tests.Logging
+{
+    [TestFixture]
+    public class NullLoggerUnitTests
+    {
+        private ILogger _logger;
+        private string _message = "Example message";
+
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+            _logger = new NullLogger();
+        }
+
+        [Test]
+        public void Info_does_not_throw_exception()
+        {
+            // act
+            Assert.DoesNotThrow(() => _logger.Info(_message));
+        }
+
+        [Test]
+        public void Debug_does_not_throw_exception()
+        {
+            // act
+            Assert.DoesNotThrow(() => _logger.Debug(_message));
+        }
+
+        [Test]
+        public void Warning_does_not_throw_exception()
+        {
+            // act
+            Assert.DoesNotThrow(() => _logger.Warning(_message));
+        }
+
+        [Test]
+        public void Error_does_not_throw_exception()
+        {
+            // act
+            Assert.DoesNotThrow(() => _logger.Error(_message));
+        }
+
+        [Test]
+        public void Fatal_does_not_throw_exception()
+        {
+            // act
+            Assert.DoesNotThrow(() => _logger.Fatal(_message));
+        }
+
+    }
+}

--- a/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
+++ b/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
@@ -229,6 +229,7 @@
     <Compile Include="EncompassUtils\SessionUtils.cs" />
     <Compile Include="EncompassUtils\UserUtils.cs" />
     <Compile Include="Logging\ILogger.cs" />
+    <Compile Include="Logging\NullLogger.cs" />
     <Compile Include="Logging\SerilogHelpers.cs" />
     <Compile Include="Logging\SextantLogger.cs" />
     <Compile Include="Metrics\Graphite\GraphiteReporter.cs" />

--- a/GuaranteedRate.Sextant/Logging/NullLogger.cs
+++ b/GuaranteedRate.Sextant/Logging/NullLogger.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace GuaranteedRate.Sextant.Logging
+{
+    /// <summary>
+    /// Implementation of Logger to use when no configuration settings are available.
+    /// Will disregard messages without raising exceptions.
+    /// </summary>
+    public class NullLogger : ILogger
+    {
+        public void Debug(string message) { }
+
+        public void Debug(string message, Exception exception) { }
+
+        public void Error(string message) { }
+
+        public void Error(string message, Exception exception) { }
+
+        public void Fatal(string message) { }
+
+        public void Fatal(string message, Exception exception) { }
+
+        public void Info(string message) { }
+
+        public void Info(string message, Exception exception) { }
+
+        public void Warning(string message) { }
+
+        public void Warning(string message, Exception exception) { }
+
+    }
+}

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("18.4.0.1")]
-[assembly: AssemblyFileVersion("18.4.0.1")]
+[assembly: AssemblyVersion("18.4.0.2")]
+[assembly: AssemblyFileVersion("18.4.0.2")]

--- a/README.md
+++ b/README.md
@@ -155,6 +155,46 @@ public void Sample_Logger_Info_mock()
 
 ```
 
+### NullLogger
+
+**NullLogger** is an implementation of `ILogger` for scenarios where no configuration settings are available to configure another implementation such as `SextantLogger`.
+
+This can come into play when multiple constructors for a given class are provided, and we still want to retain a valid `ILogger` reference through the class itself.
+
+Here is an example scenario for a simple Passport client.
+
+```csharp
+public class SampleClient : BaseClient, ISampleClient
+{
+    private ILogger _logger = null;
+
+    /// <summary>
+    /// Class name for this instance
+    /// </summary>
+    protected override string Name { get; } = typeof(SulleyClient).Name;
+
+    /// <summary>
+    /// Constructor for URL and token without a logger
+    /// </summary>
+    /// <param name="endpointUrl">URL for the endpoint to use for configuration</param>
+    /// <param name="token">Token for accessing the service</param>
+    public SampleClient(string endpointUrl, string token) : base(endpointUrl, token)
+    {
+		_logger = new NullLogger();
+	}
+
+    /// <summary>
+    /// Constructor using Encompass Config and using the default logger
+    /// </summary>
+    /// <param name="config"></param>
+    public SampleClient(IEncompassConfig config)
+    {
+        // create default logger
+        _logger = new SextantLogger(config, this.Name);
+    }
+
+```
+
 ## Metrics tracking
 
 ### Metrics

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ public class SampleClient : BaseClient, ISampleClient
     /// <summary>
     /// Class name for this instance
     /// </summary>
-    protected override string Name { get; } = typeof(SulleyClient).Name;
+    protected override string Name { get; } = typeof(SampleClient).Name;
 
     /// <summary>
     /// Constructor for URL and token without a logger
@@ -180,8 +180,8 @@ public class SampleClient : BaseClient, ISampleClient
     /// <param name="token">Token for accessing the service</param>
     public SampleClient(string endpointUrl, string token) : base(endpointUrl, token)
     {
-		_logger = new NullLogger();
-	}
+	_logger = new NullLogger();
+    }
 
     /// <summary>
     /// Constructor using Encompass Config and using the default logger


### PR DESCRIPTION
Based on feedback from a different code review, I added a new `NullLogger` implementation of `ILogger` to support scenarios where configuration settings aren't available.
An example use case has been added to the **Readme** file for more background.

[x] Unit tests pass?
[x] Version bumped?
[x] Changelog?
[x] Readme?