### PR TITLE
Integration tests and updated LoggingTestRig.

### DIFF
--- a/GuaranteedRate.Sextant.Integration.Tests/GuaranteedRate.Sextant.Integration.Tests.csproj
+++ b/GuaranteedRate.Sextant.Integration.Tests/GuaranteedRate.Sextant.Integration.Tests.csproj
@@ -59,6 +59,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Logging\LogIntegrationTests.cs" />
+    <Compile Include="Logging\SextantLoggerIntegrationTests.cs" />
     <Compile Include="Metrics\Datadog\DatadogReporterIntegrationTests.cs" />
     <Compile Include="Metrics\Graphite\GraphiteReporterIntegrationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/GuaranteedRate.Sextant.Integration.Tests/Logging/SextantLoggerIntegrationTests.cs
+++ b/GuaranteedRate.Sextant.Integration.Tests/Logging/SextantLoggerIntegrationTests.cs
@@ -1,0 +1,65 @@
+﻿using GuaranteedRate.Sextant.Config;
+using GuaranteedRate.Sextant.Integration.Core;
+using GuaranteedRate.Sextant.Logging;
+using NUnit.Framework;
+
+namespace GuaranteedRate.Sextant.Integration.Tests.Logging
+{
+    [TestFixture]
+    [Explicit]
+    class SextantLoggerIntegrationTests
+    {
+        private IEncompassConfig _encompassConfig;
+        private string _loggerName = "SextantLoggerIntegrationTests";
+
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+            _encompassConfig = new IntegrationEncompassConfig();
+        }
+
+        [TestFixtureTearDown]
+        public void TestFixtureTearDown()
+        {
+            Logger.Shutdown(30, true);
+            //Serilog.Log.CloseAndFlush();
+        }
+
+        [Test]
+        public void Constructor_with_config_only_returns_logger()
+        {
+            // act
+            var actual = new SextantLogger(_encompassConfig, _loggerName);
+
+            // assert
+            Assert.NotNull(actual);
+        }
+
+        [Test]
+        public void Warning_writes_to_loggly()
+        {
+            // arrange
+            var logger = new SextantLogger(_encompassConfig, _loggerName);
+
+            // act
+            logger.Warning("Test warning from integration test");
+
+            // assert
+            Assert.Pass("Check loggly for results");
+        }
+
+        [Test]
+        public void Info_writes_to_loggly()
+        {
+            // arrange
+            var logger = new SextantLogger(_encompassConfig, _loggerName);
+
+            // act
+            logger.Info("Test info from integration test");
+
+            // assert
+            Assert.Pass("Check loggly for results");
+        }
+
+    }
+}

--- a/GuaranteedRate.Sextant.Integration.Tests/app.config
+++ b/GuaranteedRate.Sextant.Integration.Tests/app.config
@@ -27,18 +27,21 @@
     <add key="FileLogAppender.LogName" value="Sextant" />
 
 
-    <add key="LogglyLogAppender.Url" value="http://my.loggly.com" />
-    <add key="LogglyLogAppender.ApiKey" value="my-api-key" />
+    <add key="LogglyLogAppender.Enabled" value="true" />
+    <add key="LogglyLogAppender.ApiKey" value="3420bf81-80fb-497b-8168-1e63dfb2f033" />
+    <add key="LogglyLogAppender.Url" value="http://logs-01.loggly.com" />
     <add key="LogglyLogAppender.QueueSize" value="1000" />
     <add key="LogglyLogAppender.RetryLimit" value="300" />
-    <add key="LogglyLogAppender.All.Enabled" value="true" />
+    <add key="LogglyLogAppender.All.Enabled" value="false" />
     <add key="LogglyLogAppender.Error.Enabled" value="true" />
     <add key="LogglyLogAppender.Warn.Enabled" value="true" />
-    <add key="LogglyLogAppender.Info.Enabled" value="true" />
-    <add key="LogglyLogAppender.Debug.Enabled" value="true" />
+    <add key="LogglyLogAppender.Info.Enabled" value="false" />
+    <add key="LogglyLogAppender.Debug.Enabled" value="false" />
     <add key="LogglyLogAppender.Fatal.Enabled" value="true" />
     <add key="LogglyLogAppender.Tags" value="dev,project1" />
-    
+
+    <add key="Encompass.Environment" value="dev" />
+
     <!-- Metrics -->
     <add key="GraphiteReporter.Enabled" value="true" />
     <add key="GraphiteReporter.Host" value="my.graphite.com" />

--- a/GuaranteedRate.Sextant/Logging/SerilogHelpers.cs
+++ b/GuaranteedRate.Sextant/Logging/SerilogHelpers.cs
@@ -115,7 +115,7 @@ namespace GuaranteedRate.Sextant.Logging
 
             var lc = new LogglyConfiguration();
             lc.CustomerToken = config.GetValue(Logger.LOGGLY_APIKEY);
-            lc.EndpointHostName = config.GetValue(Logger.LOGGLY_URL, "logs-01.loggly.com").Replace("https://", "");
+            lc.EndpointHostName = config.GetValue(Logger.LOGGLY_URL, "logs-01.loggly.com").Replace("https://", "").Replace("http://", "");
             lc.EndpointPort = 443;
             lc.ThrowExceptions = true;
             lc.ApplicationName = config.GetValue(Logger.LOGGLY_APPLICATION_NAME, "Unnamed Sextant App");

--- a/LoggingTestRig/App.config
+++ b/LoggingTestRig/App.config
@@ -1,5 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <appSettings>
+    <add key="LogglyLogAppender.Enabled" value="true" />
+    <add key="LogglyLogAppender.ApiKey" value="3420bf81-80fb-497b-8168-1e63dfb2f033" />
+    <add key="LogglyLogAppender.Url" value="http://logs-01.loggly.com" />
+    <add key="LogglyLogAppender.QueueSize" value="1000" />
+    <add key="LogglyLogAppender.RetryLimit" value="300" />
+    <add key="LogglyLogAppender.All.Enabled" value="false" />
+    <add key="LogglyLogAppender.Error.Enabled" value="true" />
+    <add key="LogglyLogAppender.Warn.Enabled" value="false" />
+    <add key="LogglyLogAppender.Info.Enabled" value="false" />
+    <add key="LogglyLogAppender.Debug.Enabled" value="false" />
+    <add key="LogglyLogAppender.Fatal.Enabled" value="true" />
+    <add key="LogglyLogAppender.Tags" value="dev,project1" />
+
+    <add key="Encompass.Environment" value="dev" />
+
+  </appSettings>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>

--- a/LoggingTestRig/LoggingTestRig.csproj
+++ b/LoggingTestRig/LoggingTestRig.csproj
@@ -223,6 +223,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GuaranteedRate.Sextant.Integration.Core\GuaranteedRate.Sextant.Integration.Core.csproj">
+      <Project>{1C0A0D30-1FCE-4650-8B36-4611DA6C1546}</Project>
+      <Name>GuaranteedRate.Sextant.Integration.Core</Name>
+    </ProjectReference>
     <ProjectReference Include="..\GuaranteedRate.Sextant\GuaranteedRate.Sextant.csproj">
       <Project>{6388e4a7-456a-4363-9ac4-936f742ca63f}</Project>
       <Name>GuaranteedRate.Sextant</Name>

--- a/LoggingTestRig/Program.cs
+++ b/LoggingTestRig/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GuaranteedRate.Sextant.Config;
+using GuaranteedRate.Sextant.Integration.Core;
 using GuaranteedRate.Sextant.Logging;
 using GuaranteedRate.Sextant.Metrics;
 using GuaranteedRate.Sextant.Metrics.Datadog;
@@ -30,8 +31,9 @@ namespace LoggingTestRig
         {
 
             int count = 0;
-            var config = new JsonEncompassConfig();
-            config.Init(System.IO.File.ReadAllText("../../SextantConfigTest.json"));
+            var config = new IntegrationEncompassConfig();
+            //var config = new JsonEncompassConfig();
+            //config.Init(System.IO.File.ReadAllText("../../SextantConfigTest.json"));
 
             //manually set appenders    
             // var console = new ConsoleLogAppender(config);


### PR DESCRIPTION
One key change to `SerilogHelper.cs` that was tripping me up for older configuration files that were using `http` instead of `https` in them.

Other than that, just new integration tests and updates to the test rig that let you toggle the settings in `App.config`, run the tests, and then check to make sure only the correct log entries show up in Loggly.