### PR TITLE
[SessionRecovery] New session exceptions to help with error handling and retry logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v18.4.0.4 / 2019 Feb 1
+
+* **Add** - Added strongly typed exceptions to `SessionUtils.GetEncompassSession` for consuming applications to customize error handling and retry policies based on various session errors.
+
 ## v18.4.0.3 / 2019 Jan 22
 
 * **Update** - Updated Logger class to be able to resolve logging levels from the passed in Config file

--- a/GuaranteedRate.Sextant.Integration.Tests/EncompassUtils/SessionUtilsTests.cs
+++ b/GuaranteedRate.Sextant.Integration.Tests/EncompassUtils/SessionUtilsTests.cs
@@ -1,0 +1,64 @@
+﻿using GuaranteedRate.Sextant.EncompassUtils;
+using GuaranteedRate.Sextant.Exceptions;
+using NUnit.Framework;
+
+namespace GuaranteedRate.Sextant.Integration.Tests.EncompassUtils
+{
+    [TestFixture]
+    [Explicit]
+    public class SessionUtilsTests
+    {
+        [Test]
+        public void GetEncompassSession_with_invalid_url_throws_connection_exception()
+        {
+            // arrange
+            var encompassUrl = "https://TEBE11158xxx.ea.elliemae.net$TEBE11158xxx";
+            var login = "testlo";
+            var pw = "password";
+
+            // act
+            Assert.Throws<ServerConnectionException>(() =>
+            {
+                var actual = SessionUtils.GetEncompassSession(encompassUrl, login, pw);
+            });
+        }
+
+
+        [Test]
+        public void GetEncompassSession_with_invalid_login_throws_login_exception()
+        {
+            // arrange
+            var encompassUrl = "https://TEBE11158661.ea.elliemae.net$TEBE11158661";
+            var login = "testloooooo";
+            var pw = "password";
+
+            // act
+            var ex = Assert.Throws<ServerLoginException>(() =>
+            {
+                var actual = SessionUtils.GetEncompassSession(encompassUrl, login, pw);
+            });
+
+            // assert error type
+            Assert.AreEqual(ServerLoginException.ErrorTypes.UserNotFound, ex.ErrorType);
+        }
+
+        [Test]
+        public void GetEncompassSession_with_invalid_password_throws_login_exception()
+        {
+            // arrange
+            var encompassUrl = "https://TEBE11158661.ea.elliemae.net$TEBE11158661";
+            var login = "testlo";
+            var pw = "not_my_password";
+
+            // act
+            var ex = Assert.Throws<ServerLoginException>(() =>
+            {
+                var actual = SessionUtils.GetEncompassSession(encompassUrl, login, pw);
+            });
+
+            // assert error type
+            Assert.AreEqual(ServerLoginException.ErrorTypes.InvalidPassword, ex.ErrorType);
+        }
+
+    }
+}

--- a/GuaranteedRate.Sextant.Integration.Tests/EncompassUtils/SessionUtilsTests.cs
+++ b/GuaranteedRate.Sextant.Integration.Tests/EncompassUtils/SessionUtilsTests.cs
@@ -12,7 +12,7 @@ namespace GuaranteedRate.Sextant.Integration.Tests.EncompassUtils
         public void GetEncompassSession_with_invalid_url_throws_connection_exception()
         {
             // arrange
-            var encompassUrl = "https://TEBE11158xxx.ea.elliemae.net$TEBE11158xxx";
+            var encompassUrl = "https://TExxx.ea.elliemae.net$TExxx";
             var login = "testlo";
             var pw = "password";
 
@@ -28,7 +28,7 @@ namespace GuaranteedRate.Sextant.Integration.Tests.EncompassUtils
         public void GetEncompassSession_with_invalid_login_throws_login_exception()
         {
             // arrange
-            var encompassUrl = "https://TEBE11158661.ea.elliemae.net$TEBE11158661";
+            var encompassUrl = "https://ADD_VALID_SERVER_URL_HERE";
             var login = "testloooooo";
             var pw = "password";
 
@@ -46,7 +46,7 @@ namespace GuaranteedRate.Sextant.Integration.Tests.EncompassUtils
         public void GetEncompassSession_with_invalid_password_throws_login_exception()
         {
             // arrange
-            var encompassUrl = "https://TEBE11158661.ea.elliemae.net$TEBE11158661";
+            var encompassUrl = "https://ADD_VALID_SERVER_URL_HERE";
             var login = "testlo";
             var pw = "not_my_password";
 

--- a/GuaranteedRate.Sextant.Integration.Tests/GuaranteedRate.Sextant.Integration.Tests.csproj
+++ b/GuaranteedRate.Sextant.Integration.Tests/GuaranteedRate.Sextant.Integration.Tests.csproj
@@ -35,6 +35,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EncompassObjects, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91" />
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -58,6 +59,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="EncompassUtils\SessionUtilsTests.cs" />
     <Compile Include="Logging\LogIntegrationTests.cs" />
     <Compile Include="Logging\SextantLoggerIntegrationTests.cs" />
     <Compile Include="Metrics\Datadog\DatadogReporterIntegrationTests.cs" />

--- a/GuaranteedRate.Sextant.Integration.Tests/app.config
+++ b/GuaranteedRate.Sextant.Integration.Tests/app.config
@@ -28,7 +28,7 @@
 
 
     <add key="LogglyLogAppender.Enabled" value="true" />
-    <add key="LogglyLogAppender.ApiKey" value="3420bf81-80fb-497b-8168-1e63dfb2f033" />
+    <add key="LogglyLogAppender.ApiKey" value="ADD_VALID_API_KEY_HERE" />
     <add key="LogglyLogAppender.Url" value="http://logs-01.loggly.com" />
     <add key="LogglyLogAppender.QueueSize" value="1000" />
     <add key="LogglyLogAppender.RetryLimit" value="300" />

--- a/GuaranteedRate.Sextant/Exceptions/ServerConnectionException.cs
+++ b/GuaranteedRate.Sextant/Exceptions/ServerConnectionException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace GuaranteedRate.Sextant.Exceptions
+{
+    /// <summary>
+    /// Represents an exception related to a Server Connection
+    /// </summary>
+    public class ServerConnectionException : Exception
+    {
+        public ServerConnectionException(string message) : base(message) { }
+
+        public ServerConnectionException(string message, Exception innerException) : base(message, innerException) { }
+
+    }
+}

--- a/GuaranteedRate.Sextant/Exceptions/ServerLoginException.cs
+++ b/GuaranteedRate.Sextant/Exceptions/ServerLoginException.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GuaranteedRate.Sextant.Exceptions
+{
+    /// <summary>
+    /// Represents an exception related to logging into a server
+    /// </summary>
+    public class ServerLoginException : Exception
+    {
+        public ErrorTypes ErrorType { get; private set; }
+
+        public ServerLoginException(string message) : base(message) { this.ErrorType = ErrorTypes.Unspecified; }
+
+        public ServerLoginException(string message, Exception innerException) : base(message, innerException) { this.ErrorType = ErrorTypes.Unspecified; }
+
+        public ServerLoginException(string message, Exception innerException, ErrorTypes errorType) : base(message, innerException) { this.ErrorType = errorType; }
+
+
+        /// <summary>
+        /// List of known error types, for now, mapped from: EllieMae.Encompass.Client.LoginErrorType
+        /// </summary>
+        public enum ErrorTypes
+        {
+            Unspecified = 0,
+            UserNotFound = 1,
+            InvalidPassword = 2,
+            UserDiabled = 4,
+            LoginsDisabled = 5,
+            ServerError = 6,
+            UserLocked = 7,
+            InvalidPersona = 8,
+            ConcurrentEditingOfflineNotAllowed = 9,
+            IPBlocked = 10,
+            ServerBusy = 12,
+            APIUserRestricted = 13
+        }
+    }
+}

--- a/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
+++ b/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
@@ -228,6 +228,8 @@
     <Compile Include="EncompassUtils\Reporting.cs" />
     <Compile Include="EncompassUtils\SessionUtils.cs" />
     <Compile Include="EncompassUtils\UserUtils.cs" />
+    <Compile Include="Exceptions\ServerConnectionException.cs" />
+    <Compile Include="Exceptions\ServerLoginException.cs" />
     <Compile Include="Logging\ILogger.cs" />
     <Compile Include="Logging\NullLogger.cs" />
     <Compile Include="Logging\SerilogHelpers.cs" />

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("18.4.0.3")]
-[assembly: AssemblyFileVersion("18.4.0.3")]
+[assembly: AssemblyVersion("18.4.0.4")]
+[assembly: AssemblyFileVersion("18.4.0.4")]

--- a/LoggingTestRig/App.config
+++ b/LoggingTestRig/App.config
@@ -2,7 +2,7 @@
 <configuration>
   <appSettings>
     <add key="LogglyLogAppender.Enabled" value="true" />
-    <add key="LogglyLogAppender.ApiKey" value="3420bf81-80fb-497b-8168-1e63dfb2f033" />
+    <add key="LogglyLogAppender.ApiKey" value="ADD_API_KEY_HERE" />
     <add key="LogglyLogAppender.Url" value="http://logs-01.loggly.com" />
     <add key="LogglyLogAppender.QueueSize" value="1000" />
     <add key="LogglyLogAppender.RetryLimit" value="300" />


### PR DESCRIPTION
New session exceptions to help with error handling and retry logic. 

These changes are intended to make it easier to customize retry policies for things like Task Processor 3, based on the different reasons why an Encompass session could not be created.

- [x] Unit tests pass?
- [x] Version updated.
- [x] Changelog updated.
- [ ] Readme?