### PR TITLE
IsBusinessDay helper method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v19.1.0.2 / 2019 Apr 8
+
+* **Add** - New method `IsBusinessDay` helper method in `SessionUtils`
+
 ## v19.1.0.1 / 2019 Apr 3
 
 * **Update** - Updated to EncompassSDK.Complete 19.1 for the Encompass Upgrade

--- a/GuaranteedRate.Sextant/EncompassUtils/SessionUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/SessionUtils.cs
@@ -1,6 +1,7 @@
 ﻿using EllieMae.Encompass.BusinessObjects.Loans;
 using EllieMae.Encompass.Client;
 using EllieMae.Encompass.Collections;
+using EllieMae.Encompass.Configuration;
 using EllieMae.Encompass.Query;
 using GuaranteedRate.Sextant.Exceptions;
 using System;
@@ -102,6 +103,17 @@ namespace GuaranteedRate.Sextant.EncompassUtils
             {
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Checks the system settings for the provided Session to determine if the Date provided is a Business Day
+        /// </summary>
+        /// <param name="session"></param>
+        /// <param name="dateValue"></param>
+        /// <returns></returns>
+        public static bool IsBusinessDay(Session session, DateTime dateValue)
+        {
+            return session.SystemSettings.GetBusinessCalendar(BusinessCalendarType.Company).GetDayType(dateValue) == BusinessCalendarDayType.BusinessDay;
         }
     }
 }

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("19.1.0.1")]
-[assembly: AssemblyFileVersion("19.1.0.1")]
+[assembly: AssemblyVersion("19.1.0.2")]
+[assembly: AssemblyFileVersion("19.1.0.2")]


### PR DESCRIPTION
Added method for checking if date is a Business Day in Encompass.

Included as part of `SessionUtils` since it requires a `Session` instance in order to access the calendar settings in Encompass.