### PR TITLE
Elastic Search 6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v19.1.0.2 / 2019 May 20
+
+* **Update** - Updated `Elasticsearch.net` to 6.0.1
+* **Update** - Updated `Serilog` and `Serilog.Sinks.ElasticSearch` packages required for Elastic Search 6.0.1
+
 ## v19.1.0.1 / 2019 Apr 3
 
 * **Update** - Updated to EncompassSDK.Complete 19.1 for the Encompass Upgrade

--- a/GuaranteedRate.Examples.FieldUtils/GuaranteedRate.Examples.FieldUtils.csproj
+++ b/GuaranteedRate.Examples.FieldUtils/GuaranteedRate.Examples.FieldUtils.csproj
@@ -148,7 +148,7 @@
       <HintPath>..\packages\EncompassSDK.Complete.19.1.0.2\lib\net45\SDKConfigImpl.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>

--- a/GuaranteedRate.Examples.FieldUtils/packages.config
+++ b/GuaranteedRate.Examples.FieldUtils/packages.config
@@ -7,7 +7,7 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="RazorEngine" version="3.9.3" targetFramework="net452" />
   <package id="RestSharp" version="106.3.1" targetFramework="net452" />
-  <package id="Serilog" version="2.5.0" targetFramework="net452" />
+  <package id="Serilog" version="2.6.0" targetFramework="net452" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Loggly" version="5.3.0" targetFramework="net452" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net452" />

--- a/GuaranteedRate.Examples.LoanDataUtils/GuaranteedRate.Examples.LoanDataUtils.csproj
+++ b/GuaranteedRate.Examples.LoanDataUtils/GuaranteedRate.Examples.LoanDataUtils.csproj
@@ -149,7 +149,7 @@
       <HintPath>..\packages\EncompassSDK.Complete.19.1.0.2\lib\net45\SDKConfigImpl.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>

--- a/GuaranteedRate.Examples.LoanDataUtils/packages.config
+++ b/GuaranteedRate.Examples.LoanDataUtils/packages.config
@@ -7,7 +7,7 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="RazorEngine" version="3.9.3" targetFramework="net452" />
   <package id="RestSharp" version="106.3.1" targetFramework="net452" />
-  <package id="Serilog" version="2.5.0" targetFramework="net452" />
+  <package id="Serilog" version="2.6.0" targetFramework="net452" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Loggly" version="5.3.0" targetFramework="net452" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net452" />

--- a/GuaranteedRate.Examples.ReportingUtils/GuaranteedRate.Examples.ReportingUtils.csproj
+++ b/GuaranteedRate.Examples.ReportingUtils/GuaranteedRate.Examples.ReportingUtils.csproj
@@ -148,7 +148,7 @@
       <HintPath>..\packages\EncompassSDK.Complete.19.1.0.2\lib\net45\SDKConfigImpl.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>

--- a/GuaranteedRate.Examples.ReportingUtils/packages.config
+++ b/GuaranteedRate.Examples.ReportingUtils/packages.config
@@ -7,7 +7,7 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="RazorEngine" version="3.9.3" targetFramework="net452" />
   <package id="RestSharp" version="106.3.1" targetFramework="net452" />
-  <package id="Serilog" version="2.5.0" targetFramework="net452" />
+  <package id="Serilog" version="2.6.0" targetFramework="net452" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Loggly" version="5.3.0" targetFramework="net452" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net452" />

--- a/GuaranteedRate.Examples.UserUtils/GuaranteedRate.Examples.UserUtils.csproj
+++ b/GuaranteedRate.Examples.UserUtils/GuaranteedRate.Examples.UserUtils.csproj
@@ -148,7 +148,7 @@
       <HintPath>..\packages\EncompassSDK.Complete.19.1.0.2\lib\net45\SDKConfigImpl.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>

--- a/GuaranteedRate.Examples.UserUtils/packages.config
+++ b/GuaranteedRate.Examples.UserUtils/packages.config
@@ -7,7 +7,7 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="RazorEngine" version="3.9.3" targetFramework="net452" />
   <package id="RestSharp" version="106.3.1" targetFramework="net452" />
-  <package id="Serilog" version="2.5.0" targetFramework="net452" />
+  <package id="Serilog" version="2.6.0" targetFramework="net452" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Loggly" version="5.3.0" targetFramework="net452" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net452" />

--- a/GuaranteedRate.Sextant.ConsoleTester/GuaranteedRate.Sextant.ConsoleTester.csproj
+++ b/GuaranteedRate.Sextant.ConsoleTester/GuaranteedRate.Sextant.ConsoleTester.csproj
@@ -148,7 +148,7 @@
       <HintPath>..\packages\EncompassSDK.Complete.19.1.0.2\lib\net45\SDKConfigImpl.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>

--- a/GuaranteedRate.Sextant.ConsoleTester/packages.config
+++ b/GuaranteedRate.Sextant.ConsoleTester/packages.config
@@ -7,7 +7,7 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="RazorEngine" version="3.9.3" targetFramework="net452" />
   <package id="RestSharp" version="106.3.1" targetFramework="net452" />
-  <package id="Serilog" version="2.5.0" targetFramework="net452" />
+  <package id="Serilog" version="2.6.0" targetFramework="net452" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Loggly" version="5.3.0" targetFramework="net452" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net452" />

--- a/GuaranteedRate.Sextant.CustomFieldComparer/GuaranteedRate.Sextant.CustomFieldComparer.csproj
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/GuaranteedRate.Sextant.CustomFieldComparer.csproj
@@ -165,7 +165,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>

--- a/GuaranteedRate.Sextant.CustomFieldComparer/packages.config
+++ b/GuaranteedRate.Sextant.CustomFieldComparer/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
-  <package id="Serilog" version="2.5.0" targetFramework="net452" />
+  <package id="Serilog" version="2.6.0" targetFramework="net452" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net452" />
 </packages>

--- a/GuaranteedRate.Sextant.Integration.Core/GuaranteedRate.Sextant.Integration.Core.csproj
+++ b/GuaranteedRate.Sextant.Integration.Core/GuaranteedRate.Sextant.Integration.Core.csproj
@@ -151,7 +151,7 @@
       <HintPath>..\packages\EncompassSDK.Complete.19.1.0.2\lib\net45\SDKConfigImpl.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>

--- a/GuaranteedRate.Sextant.Integration.Core/packages.config
+++ b/GuaranteedRate.Sextant.Integration.Core/packages.config
@@ -7,7 +7,7 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="RazorEngine" version="3.9.3" targetFramework="net452" />
   <package id="RestSharp" version="106.3.1" targetFramework="net452" />
-  <package id="Serilog" version="2.5.0" targetFramework="net452" />
+  <package id="Serilog" version="2.6.0" targetFramework="net452" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Loggly" version="5.3.0" targetFramework="net452" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net452" />

--- a/GuaranteedRate.Sextant.Tests/GuaranteedRate.Sextant.Tests.csproj
+++ b/GuaranteedRate.Sextant.Tests/GuaranteedRate.Sextant.Tests.csproj
@@ -164,7 +164,7 @@
       <HintPath>..\packages\EncompassSDK.Complete.19.1.0.2\lib\net45\SDKConfigImpl.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>

--- a/GuaranteedRate.Sextant.Tests/packages.config
+++ b/GuaranteedRate.Sextant.Tests/packages.config
@@ -11,7 +11,7 @@
   <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net452" />
   <package id="RazorEngine" version="3.9.3" targetFramework="net452" />
   <package id="RestSharp" version="106.3.1" targetFramework="net452" />
-  <package id="Serilog" version="2.5.0" targetFramework="net452" />
+  <package id="Serilog" version="2.6.0" targetFramework="net452" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Loggly" version="5.3.0" targetFramework="net452" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net452" />

--- a/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
+++ b/GuaranteedRate.Sextant/GuaranteedRate.Sextant.csproj
@@ -51,9 +51,8 @@
     <Reference Include="DocumentConverter, Version=7.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
       <HintPath>..\packages\EncompassSDK.Complete.19.1.0.2\lib\net45\DocumentConverter.dll</HintPath>
     </Reference>
-    <Reference Include="Elasticsearch.Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.5.5.0\lib\net45\Elasticsearch.Net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Elasticsearch.Net, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elasticsearch.Net.6.0.1\lib\net45\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="Elli.AdvCode, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
       <HintPath>..\packages\EncompassSDK.Complete.19.1.0.2\lib\net45\Elli.AdvCode.dll</HintPath>
@@ -161,16 +160,14 @@
       <HintPath>..\packages\EncompassSDK.Complete.19.1.0.2\lib\net45\SDKConfigImpl.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.Console, Version=3.1.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Console.3.1.1\lib\net45\Serilog.Sinks.Console.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.Sinks.Elasticsearch, Version=5.7.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.Sinks.Elasticsearch.5.7.0\lib\net45\Serilog.Sinks.Elasticsearch.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog.Sinks.Elasticsearch, Version=6.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Elasticsearch.6.5.0\lib\net45\Serilog.Sinks.Elasticsearch.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("19.1.0.1")]
-[assembly: AssemblyFileVersion("19.1.0.1")]
+[assembly: AssemblyVersion("19.1.0.2")]
+[assembly: AssemblyFileVersion("19.1.0.2")]

--- a/GuaranteedRate.Sextant/packages.config
+++ b/GuaranteedRate.Sextant/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="5.5.0" targetFramework="net452" />
+  <package id="Elasticsearch.Net" version="6.0.1" targetFramework="net452" />
   <package id="EncompassSDK.Complete" version="19.1.0.2" targetFramework="net452" />
   <package id="loggly-csharp" version="4.6.1.55" targetFramework="net452" />
   <package id="loggly-csharp-config" version="4.6.1.55" targetFramework="net452" />
@@ -11,9 +11,9 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="RazorEngine" version="3.9.3" targetFramework="net452" />
   <package id="RestSharp" version="106.3.1" targetFramework="net452" />
-  <package id="Serilog" version="2.5.0" targetFramework="net452" />
+  <package id="Serilog" version="2.6.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net452" />
-  <package id="Serilog.Sinks.Elasticsearch" version="5.7.0" targetFramework="net452" />
+  <package id="Serilog.Sinks.Elasticsearch" version="6.5.0" targetFramework="net452" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Loggly" version="5.3.0" targetFramework="net452" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net452" />

--- a/GuaranteedRate.Util.IndexFields/GuaranteedRate.Util.IndexFields.csproj
+++ b/GuaranteedRate.Util.IndexFields/GuaranteedRate.Util.IndexFields.csproj
@@ -148,7 +148,7 @@
       <HintPath>..\packages\EncompassSDK.Complete.19.1.0.2\lib\net45\SDKConfigImpl.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>

--- a/GuaranteedRate.Util.IndexFields/packages.config
+++ b/GuaranteedRate.Util.IndexFields/packages.config
@@ -7,7 +7,7 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="RazorEngine" version="3.9.3" targetFramework="net452" />
   <package id="RestSharp" version="106.3.1" targetFramework="net452" />
-  <package id="Serilog" version="2.5.0" targetFramework="net452" />
+  <package id="Serilog" version="2.6.0" targetFramework="net452" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Loggly" version="5.3.0" targetFramework="net452" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net452" />

--- a/LoggingTestRig/LoggingTestRig.csproj
+++ b/LoggingTestRig/LoggingTestRig.csproj
@@ -161,8 +161,7 @@
       <HintPath>..\packages\EncompassSDK.Complete.19.1.0.2\lib\net45\SDKConfigImpl.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.Console, Version=3.1.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Console.3.1.1\lib\net45\Serilog.Sinks.Console.dll</HintPath>

--- a/LoggingTestRig/packages.config
+++ b/LoggingTestRig/packages.config
@@ -10,7 +10,7 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="RazorEngine" version="3.9.3" targetFramework="net452" />
   <package id="RestSharp" version="106.3.1" targetFramework="net452" />
-  <package id="Serilog" version="2.5.0" targetFramework="net452" />
+  <package id="Serilog" version="2.6.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net452" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net452" />
   <package id="Serilog.Sinks.Loggly" version="5.3.0" targetFramework="net452" />


### PR DESCRIPTION
NuGet package updates required for supporting Elastic Search 6.0.1:
- Updated `Elasticsearch.net` to 6.0.1
- Updated `Serilog.Sinks.Elasticsearch` to 6.5.0, as required for Elastic Search 6.x
- Updated `Serilog` to 2.6.0, as required for `Serilog.Sinks.Elasticsearch`

The `.nuspec` file for Sextant should be automatically updated by the build server once these changes are merged, but I will verify that is the case before moving onto the next set of changes.

- [x] Unit tests pass?
- [x] Version updated.
- [x] Changelog updated.
- [ ] Readme?