### PR TITLE
[LOS-451] Optional tags per log statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v19.3.1.0 / 2019 September 5
+* **Add** - Optional tags for Logger methods `Info`, `Error`, `Warn`, `Debug`, and `Fatal`
+
 ## v19.3.0.2 / 2019 August 20
 * **Update** - Upgraded to EncompassSDK.Complete 19.3.0.2 for Encompass Upgrade
 

--- a/GuaranteedRate.Sextant.Integration.Tests/GuaranteedRate.Sextant.Integration.Tests.csproj
+++ b/GuaranteedRate.Sextant.Integration.Tests/GuaranteedRate.Sextant.Integration.Tests.csproj
@@ -16,6 +16,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,7 +37,90 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EncompassObjects, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91" />
+    <Reference Include="Client, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\Client.dll</HintPath>
+    </Reference>
+    <Reference Include="ClientCommon, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\ClientCommon.dll</HintPath>
+    </Reference>
+    <Reference Include="ClientServer, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\ClientServer.dll</HintPath>
+    </Reference>
+    <Reference Include="ClientSession, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\ClientSession.dll</HintPath>
+    </Reference>
+    <Reference Include="DataAccess, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\DataAccess.dll</HintPath>
+    </Reference>
+    <Reference Include="DocumentConverter, Version=7.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\DocumentConverter.dll</HintPath>
+    </Reference>
+    <Reference Include="Elli.AdvCode, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\Elli.AdvCode.dll</HintPath>
+    </Reference>
+    <Reference Include="Elli.ElliEnum, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\Elli.ElliEnum.dll</HintPath>
+    </Reference>
+    <Reference Include="Elli.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\Elli.Interface.dll</HintPath>
+    </Reference>
+    <Reference Include="Elli.Metrics, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\Elli.Metrics.dll</HintPath>
+    </Reference>
+    <Reference Include="Elli.Server.Remoting, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\Elli.Server.Remoting.dll</HintPath>
+    </Reference>
+    <Reference Include="EllieMae.Encompass.AsmResolver, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\EllieMae.Encompass.AsmResolver.dll</HintPath>
+    </Reference>
+    <Reference Include="EllieMae.Encompass.Runtime, Version=3.5.1.5, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\EllieMae.Encompass.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="EMBAM15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\EMBAM15.dll</HintPath>
+    </Reference>
+    <Reference Include="EMCommon, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\EMCommon.dll</HintPath>
+    </Reference>
+    <Reference Include="EMExport, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\EMExport.dll</HintPath>
+    </Reference>
+    <Reference Include="EMLoanUtils15, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\EMLoanUtils15.dll</HintPath>
+    </Reference>
+    <Reference Include="EncompassAutomation, Version=19.3.0.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\EncompassAutomation.dll</HintPath>
+    </Reference>
+    <Reference Include="EncompassObjects, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\EncompassObjects.dll</HintPath>
+    </Reference>
+    <Reference Include="GdPicture.NET.14, Version=14.0.0.50, Culture=neutral, PublicKeyToken=f52a2e60ad468dbb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\GdPicture.NET.14.dll</HintPath>
+    </Reference>
+    <Reference Include="GenuineChannels, Version=2.4.3.54, Culture=neutral, PublicKeyToken=65fda4a3fde44959, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\GenuineChannels.dll</HintPath>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.84.0.0, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
+    <Reference Include="Import, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\Import.dll</HintPath>
+    </Reference>
+    <Reference Include="Infragistics2.Shared.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\Infragistics2.Shared.v7.1.dll</HintPath>
+    </Reference>
+    <Reference Include="Infragistics2.Win.UltraWinSchedule.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\Infragistics2.Win.UltraWinSchedule.v7.1.dll</HintPath>
+    </Reference>
+    <Reference Include="Infragistics2.Win.v7.1, Version=7.1.20071.40, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\Infragistics2.Win.v7.1.dll</HintPath>
+    </Reference>
+    <Reference Include="itextsharp, Version=5.0.2.0, Culture=neutral, PublicKeyToken=8354ae6d2174ddca, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\itextsharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Jed, Version=1.0.1234.56789, Culture=neutral, PublicKeyToken=d11ef57bba4acf91">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\Jed.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -44,7 +129,38 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PostSharp, Version=3.1.41.9, Culture=neutral, PublicKeyToken=b13fd38b8f9c99d7, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\PostSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="RazorEngine, Version=3.9.3.0, Culture=neutral, PublicKeyToken=9ee697374c7e744a, processorArchitecture=MSIL">
+      <HintPath>..\packages\RazorEngine.3.9.3\lib\net45\RazorEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="ReportingDbUtils, Version=6.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\ReportingDbUtils.dll</HintPath>
+    </Reference>
+    <Reference Include="RestSharp, Version=106.3.1.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.3.1\lib\net452\RestSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="SDKConfigImpl, Version=19.3.0.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\SDKConfigImpl.dll</HintPath>
+    </Reference>
+    <Reference Include="Server, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\Server.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpZipLib, Version=0.4.0.0, Culture=neutral, PublicKeyToken=fbebc9694da332b7">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\SharpZipLib.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.0.0\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="VersionInterface15, Version=1.5.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\VersionInterface15.dll</HintPath>
+    </Reference>
+    <Reference Include="Xml3WayMerge, Version=6.2.0.0, Culture=neutral, PublicKeyToken=d11ef57bba4acf91, processorArchitecture=MSIL">
+      <HintPath>..\packages\EncompassSDK.Complete.19.3.0.2\lib\net45\Xml3WayMerge.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -101,6 +217,13 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\EncompassSDK.Complete.19.3.0.2\Build\EncompassSDK.Complete.targets" Condition="Exists('..\packages\EncompassSDK.Complete.19.3.0.2\Build\EncompassSDK.Complete.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\EncompassSDK.Complete.19.3.0.2\Build\EncompassSDK.Complete.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EncompassSDK.Complete.19.3.0.2\Build\EncompassSDK.Complete.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/GuaranteedRate.Sextant.Integration.Tests/packages.config
+++ b/GuaranteedRate.Sextant.Integration.Tests/packages.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EncompassSDK.Complete" version="19.3.0.2" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Razor" version="3.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="RazorEngine" version="3.9.3" targetFramework="net452" />
+  <package id="RestSharp" version="106.3.1" targetFramework="net452" />
 </packages>

--- a/GuaranteedRate.Sextant.Tests/Logging/SextantLoggerUnitTests.cs
+++ b/GuaranteedRate.Sextant.Tests/Logging/SextantLoggerUnitTests.cs
@@ -12,7 +12,7 @@ namespace GuaranteedRate.Sextant.Tests.Logging
     {
         private IEncompassConfig _encompassConfig;
         private string _loggerName = "SextantUnitTests";
-
+        
         [TestFixtureSetUp]
         public void TestFixtureSetUp()
         {
@@ -66,7 +66,7 @@ namespace GuaranteedRate.Sextant.Tests.Logging
             var textToBeLogged = "Some text to log here";
             var infoMessage = string.Empty;
 
-            loggerMock.Setup(x => x.Info(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>())).Callback((string message) =>
+            loggerMock.Setup(x => x.Info(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>())).Callback((string message, IDictionary<string, string> tags) =>
             {
                 infoMessage = message;
             }).Verifiable();
@@ -76,6 +76,32 @@ namespace GuaranteedRate.Sextant.Tests.Logging
 
             // assert
             Assert.AreEqual(textToBeLogged, infoMessage);
+        }
+
+
+        [Test]
+        public void Logger_Info_with_tags_dont_conflict_names()
+        {
+            // arrange
+            var additionalTags = new Dictionary<string, string>()
+            {
+                { "tag1", "value1" },
+                { "tag2", "value2" },
+                { "mine", "first" }
+            };
+
+            var logger = new SextantLogger(_encompassConfig, _loggerName, additionalTags);
+
+            var tags = new Dictionary<string, string>()
+            {
+                { "tag3", "value3" },
+                { "mine", "second" },
+                { "processid", "dont break" }
+            };
+
+            // act
+            Assert.DoesNotThrow(() => logger.Info("Some message", tags));
+
         }
 
     }

--- a/GuaranteedRate.Sextant.Tests/Logging/SextantLoggerUnitTests.cs
+++ b/GuaranteedRate.Sextant.Tests/Logging/SextantLoggerUnitTests.cs
@@ -66,7 +66,7 @@ namespace GuaranteedRate.Sextant.Tests.Logging
             var textToBeLogged = "Some text to log here";
             var infoMessage = string.Empty;
 
-            loggerMock.Setup(x => x.Info(It.IsAny<string>())).Callback((string message) =>
+            loggerMock.Setup(x => x.Info(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>())).Callback((string message) =>
             {
                 infoMessage = message;
             }).Verifiable();

--- a/GuaranteedRate.Sextant/Config/JsonEncompassConfig.cs
+++ b/GuaranteedRate.Sextant/Config/JsonEncompassConfig.cs
@@ -187,7 +187,10 @@ namespace GuaranteedRate.Sextant.Config
                 return null;
             }
 
-            return new JsonEncompassConfig(val.ToString());
+            var config = new JsonEncompassConfig();
+            config.Init(val.ToString());
+
+            return config;
         }
 
         /// <summary>

--- a/GuaranteedRate.Sextant/Logging/ILogger.cs
+++ b/GuaranteedRate.Sextant/Logging/ILogger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace GuaranteedRate.Sextant.Logging
 {
@@ -12,65 +13,75 @@ namespace GuaranteedRate.Sextant.Logging
         /// Informations the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        void Info(string message);
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        void Info(string message, IDictionary<string, string> tags = null);
 
         /// <summary>
         /// Informations the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
-        void Info(string message, Exception exception);
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        void Info(string message, Exception exception, IDictionary<string, string> tags = null);
 
         /// <summary>
         /// Debugs the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        void Debug(string message);
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        void Debug(string message, IDictionary<string, string> tags = null);
 
         /// <summary>
         /// Debugs the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
-        void Debug(string message, Exception exception);
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        void Debug(string message, Exception exception, IDictionary<string, string> tags = null);
 
         /// <summary>
         /// Warnings the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        void Warning(string message);
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        void Warning(string message, IDictionary<string, string> tags = null);
 
         /// <summary>
         /// Warnings the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
-        void Warning(string message, Exception exception);
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        void Warning(string message, Exception exception, IDictionary<string, string> tags = null);
 
         /// <summary>
         /// Errors the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        void Error(string message);
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        void Error(string message, IDictionary<string, string> tags = null);
 
         /// <summary>
         /// Errors the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
-        void Error(string message, Exception exception);
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        void Error(string message, Exception exception, IDictionary<string, string> tags = null);
 
         /// <summary>
         /// Fatals the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        void Fatal(string message);
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        void Fatal(string message, IDictionary<string, string> tags = null);
 
         /// <summary>
         /// Fatals the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
-        void Fatal(string message, Exception exception);
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        void Fatal(string message, Exception exception, IDictionary<string, string> tags = null);
     }
 }

--- a/GuaranteedRate.Sextant/Logging/Logger.cs
+++ b/GuaranteedRate.Sextant/Logging/Logger.cs
@@ -194,11 +194,18 @@ namespace GuaranteedRate.Sextant.Logging
 
             return fields;
         }
-        public static void Debug(string logger, string message)
+
+        /// <summary>
+        /// writes a log entry as "debug"
+        /// </summary>
+        /// <param name="logger">e.g. 'my app'</param>
+        /// <param name="message">the log message</param>   
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public static void Debug(string logger, string message, IDictionary<string, string> tags = null)
         {
             if (configured)
             {
-                var lv = PrepLogValues(logger, message);
+                var lv = PrepLogValues(logger, message, tags);
                 Serilog.Log.Logger.Debug(lv.Item1, lv.Item2);
             }
         }
@@ -238,12 +245,12 @@ namespace GuaranteedRate.Sextant.Logging
         /// </summary>
         /// <param name="logger">e.g. 'my app'</param>
         /// <param name="message">the log message</param>   
-        /// <param name="excludedReporters">don't have these reporters process  this message.  useful so an error in a reporter doesn't log to itself and fail recursively.</param>
-        public static void Error(string logger, string message)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public static void Error(string logger, string message, IDictionary<string, string> tags = null)
         {
             if (configured)
             {
-                var lv = PrepLogValues(logger, message);
+                var lv = PrepLogValues(logger, message, tags);
                 Serilog.Log.Logger.Error(lv.Item1, lv.Item2);
             }
 
@@ -271,12 +278,12 @@ namespace GuaranteedRate.Sextant.Logging
         /// </summary>
         /// <param name="logger">e.g. 'my app'</param>
         /// <param name="message">the log message</param>   
-        /// <param name="excludedReporters">don't have these reporters process  this message.  useful so an error in a reporter doesn't log to itself and fail recursively.</param>
-        public static void Fatal(string logger, string message)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public static void Fatal(string logger, string message, IDictionary<string, string> tags = null)
         {
             if (configured)
             {
-                var lv = PrepLogValues(logger, message);
+                var lv = PrepLogValues(logger, message, tags);
                 Serilog.Log.Logger.Fatal(lv.Item1, lv.Item2);
             }
         }
@@ -286,12 +293,12 @@ namespace GuaranteedRate.Sextant.Logging
         /// </summary>
         /// <param name="logger">e.g. 'my app'</param>
         /// <param name="message">the log message</param>   
-        /// <param name="excludedReporters">don't have these reporters process  this message.  useful so an error in a reporter doesn't log to itself and fail recursively.</param>
-        public static void Info(string logger, string message)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public static void Info(string logger, string message, IDictionary<string, string> tags = null)
         {
             if (configured)
             {
-                var lv = PrepLogValues(logger, message);
+                var lv = PrepLogValues(logger, message, tags);
                 Serilog.Log.Logger.Information(lv.Item1, lv.Item2);
             }
         }
@@ -301,12 +308,12 @@ namespace GuaranteedRate.Sextant.Logging
         /// </summary>
         /// <param name="logger">e.g. 'my app'</param>
         /// <param name="message">the log message</param>   
-        /// <param name="excludedReporters">don't have these reporters process  this message.  useful so an error in a reporter doesn't log to itself and fail recursively.</param>
-        public static void Warn(string logger, string message)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public static void Warn(string logger, string message, IDictionary<string, string> tags = null)
         {
             if (configured)
             {
-                var lv = PrepLogValues(logger, message);
+                var lv = PrepLogValues(logger, message, tags);
                 Serilog.Log.Logger.Warning(lv.Item1, lv.Item2);
             }
         }

--- a/GuaranteedRate.Sextant/Logging/Logger.cs
+++ b/GuaranteedRate.Sextant/Logging/Logger.cs
@@ -103,6 +103,7 @@ namespace GuaranteedRate.Sextant.Logging
                         }
                     }
                     _additionalTags.TryAdd("process", Process.GetCurrentProcess().ProcessName);
+                    _additionalTags.TryAdd("processid", Process.GetCurrentProcess().Id.ToString());
                     _additionalTags.TryAdd("hostname", Environment.MachineName);
                     _additionalTags.TryAdd("windowsuser", Environment.UserName);
 
@@ -189,6 +190,7 @@ namespace GuaranteedRate.Sextant.Logging
 
             foreach (var tt in _additionalTags)
             {
+                if (fields.ContainsKey(tt.Key)) continue;
                 fields.Add(tt.Key, tt.Value);
             }
 

--- a/GuaranteedRate.Sextant/Logging/NullLogger.cs
+++ b/GuaranteedRate.Sextant/Logging/NullLogger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace GuaranteedRate.Sextant.Logging
 {
@@ -8,25 +9,25 @@ namespace GuaranteedRate.Sextant.Logging
     /// </summary>
     public class NullLogger : ILogger
     {
-        public void Debug(string message) { }
+        public void Debug(string message, IDictionary<string, string> tags = null) { }
 
-        public void Debug(string message, Exception exception) { }
+        public void Debug(string message, Exception exception, IDictionary<string, string> tags = null) { }
 
-        public void Error(string message) { }
+        public void Error(string message, IDictionary<string, string> tags = null) { }
 
-        public void Error(string message, Exception exception) { }
+        public void Error(string message, Exception exception, IDictionary<string, string> tags = null) { }
 
-        public void Fatal(string message) { }
+        public void Fatal(string message, IDictionary<string, string> tags = null) { }
 
-        public void Fatal(string message, Exception exception) { }
+        public void Fatal(string message, Exception exception, IDictionary<string, string> tags = null) { }
 
-        public void Info(string message) { }
+        public void Info(string message, IDictionary<string, string> tags = null) { }
 
-        public void Info(string message, Exception exception) { }
+        public void Info(string message, Exception exception, IDictionary<string, string> tags = null) { }
 
-        public void Warning(string message) { }
+        public void Warning(string message, IDictionary<string, string> tags = null) { }
 
-        public void Warning(string message, Exception exception) { }
+        public void Warning(string message, Exception exception, IDictionary<string, string> tags = null) { }
 
     }
 }

--- a/GuaranteedRate.Sextant/Logging/SextantLogger.cs
+++ b/GuaranteedRate.Sextant/Logging/SextantLogger.cs
@@ -72,9 +72,10 @@ namespace GuaranteedRate.Sextant.Logging
         /// Debugs the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        public void Debug(string message)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public void Debug(string message, IDictionary<string, string> tags = null)
         {
-            Logger.Debug(_logglyName, message);
+            Logger.Debug(_logglyName, message, tags);
         }
 
         /// <summary>
@@ -82,18 +83,20 @@ namespace GuaranteedRate.Sextant.Logging
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
-        public void Debug(string message, Exception exception)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public void Debug(string message, Exception exception, IDictionary<string, string> tags = null)
         {
-            Debug(Combine(message, exception));
+            Debug(Combine(message, exception), tags);
         }
 
         /// <summary>
         /// Informations the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        public void Info(string message)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public void Info(string message, IDictionary<string, string> tags = null)
         {
-            Logger.Info(_logglyName, message);
+            Logger.Info(_logglyName, message, tags);
         }
 
         /// <summary>
@@ -101,18 +104,20 @@ namespace GuaranteedRate.Sextant.Logging
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
-        public void Info(string message, Exception exception)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public void Info(string message, Exception exception, IDictionary<string, string> tags = null)
         {
-            Info(Combine(message, exception));
+            Info(Combine(message, exception), tags);
         }
 
         /// <summary>
         /// Warnings the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        public void Warning(string message)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public void Warning(string message, IDictionary<string, string> tags = null)
         {
-            Logger.Warn(_logglyName, message);
+            Logger.Warn(_logglyName, message, tags);
         }
 
         /// <summary>
@@ -120,18 +125,21 @@ namespace GuaranteedRate.Sextant.Logging
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
-        public void Warning(string message, Exception exception)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public void Warning(string message, Exception exception, IDictionary<string, string> tags = null)
         {
-            Warning(Combine(message, exception));
+            Warning(Combine(message, exception), tags);
 
         }
+
         /// <summary>
         /// Errors the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        public void Error(string message)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public void Error(string message, IDictionary<string, string> tags = null)
         {
-            Logger.Error(_logglyName, message);
+            Logger.Error(_logglyName, message, tags);
         }
 
         /// <summary>
@@ -139,26 +147,31 @@ namespace GuaranteedRate.Sextant.Logging
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
-        public void Error(string message, Exception exception)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public void Error(string message, Exception exception, IDictionary<string, string> tags = null)
         {
-            Error(Combine(message, exception));
+            Error(Combine(message, exception), tags);
         }
+
         /// <summary>
         /// Fatals the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        public void Fatal(string message)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public void Fatal(string message, IDictionary<string, string> tags = null)
         {
-            Logger.Fatal(_logglyName, message);
+            Logger.Fatal(_logglyName, message, tags);
         }
+
         /// <summary>
         /// Fatals the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
-        public void Fatal(string message, Exception exception)
+        /// <param name="tags">Optional tags as name/value pairs to be included in this log entry</param>
+        public void Fatal(string message, Exception exception, IDictionary<string, string> tags = null)
         {
-            Fatal(Combine(message, exception));
+            Fatal(Combine(message, exception), tags);
         }
 
         /// <summary>

--- a/GuaranteedRate.Sextant/Metrics/Graphite/GraphiteReporter.cs
+++ b/GuaranteedRate.Sextant/Metrics/Graphite/GraphiteReporter.cs
@@ -112,7 +112,7 @@ namespace GuaranteedRate.Sextant.Metrics.Graphite
             _disposedValue = true;
         }
 
-        public void Dispose()
+        public new void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);

--- a/GuaranteedRate.Sextant/Metrics/Graphite/GraphiteReporter.cs
+++ b/GuaranteedRate.Sextant/Metrics/Graphite/GraphiteReporter.cs
@@ -26,6 +26,9 @@ namespace GuaranteedRate.Sextant.Metrics.Graphite
 
         #endregion
 
+        protected override string Name { get; } = typeof(GraphiteReporter).Name;
+
+
         public GraphiteReporter(IEncompassConfig config)
             : base(config.GetValue(GRAPHITE_QUEUE_SIZE, 1000),
                 config.GetValue(GRAPHITE_RETRY_LIMIT, 3))

--- a/GuaranteedRate.Sextant/Metrics/Graphite/GraphiteReporter.cs
+++ b/GuaranteedRate.Sextant/Metrics/Graphite/GraphiteReporter.cs
@@ -87,7 +87,7 @@ namespace GuaranteedRate.Sextant.Metrics.Graphite
                 stream.Write(bytes, 0, bytes.Length);
                 stream.Close();
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return false;
             }

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("19.3.0.2")]
-[assembly: AssemblyFileVersion("19.3.0.2")]
+[assembly: AssemblyVersion("19.3.1.0")]
+[assembly: AssemblyFileVersion("19.3.1.0")]

--- a/GuaranteedRate.Sextant/WebClients/ApiException.cs
+++ b/GuaranteedRate.Sextant/WebClients/ApiException.cs
@@ -81,7 +81,7 @@ namespace GuaranteedRate.Sextant.WebClients
                     }
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 //swallow json parsing exception.  The response has nothing else to offer us
             }

--- a/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/AsyncEventReporter.cs
@@ -43,7 +43,7 @@ namespace GuaranteedRate.Sextant.WebClients
         protected const int DEFAULT_RETRIES = 3;
         protected const int DEFAULT_TIMEOUT = 45000;
 
-        protected virtual string Name { get; } = typeof(AsyncEventReporter).Name;
+        protected abstract string Name { get; }
         protected volatile bool _finished;
         protected bool LogRecurisively = true;
 

--- a/GuaranteedRate.Sextant/WebClients/AsyncWebEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/AsyncWebEventReporter.cs
@@ -27,7 +27,7 @@ namespace GuaranteedRate.Sextant.WebClients
         /// does not have any ability to relay information back to the original
         /// class that wanted the data sent.
         /// </summary>
-        public static ISet<HttpStatusCode> SUCCESS_CODES = new HashSet<HttpStatusCode>
+        public new static ISet<HttpStatusCode> SUCCESS_CODES = new HashSet<HttpStatusCode>
         {
             HttpStatusCode.Accepted,
             HttpStatusCode.Continue,
@@ -37,9 +37,9 @@ namespace GuaranteedRate.Sextant.WebClients
         };
 
         private string _url;
-        public string ContentType { get; set; } = "application/json";
+        public new string ContentType { get; set; } = "application/json";
 
-        protected virtual string Name { get; } = typeof(AsyncWebEventReporter).Name;
+        protected override string Name { get; } = typeof(AsyncWebEventReporter).Name;
 
         public AsyncWebEventReporter(string url, int queueSize = DEFAULT_QUEUE_SIZE, int retries = DEFAULT_RETRIES, int timeout = DEFAULT_TIMEOUT) : base(queueSize, retries, timeout)
         {
@@ -65,7 +65,7 @@ namespace GuaranteedRate.Sextant.WebClients
         /// prior to being processed by PostEvent
         /// </summary>
         /// <param name="webRequest"></param>
-        protected virtual void ExtraSetup(WebRequest webRequest)
+        protected override void ExtraSetup(WebRequest webRequest)
         {
 
         }

--- a/GuaranteedRate.Sextant/WebClients/AsyncWebEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/AsyncWebEventReporter.cs
@@ -21,23 +21,7 @@ namespace GuaranteedRate.Sextant.WebClients
 
     public class AsyncWebEventReporter : AsyncEventReporter, IDisposable, IEventReporter
     {
-        /// <summary>
-        /// This is the set of http status codes that are condsidered successful
-        /// responses.  The list does not include all 2xx codes because the class
-        /// does not have any ability to relay information back to the original
-        /// class that wanted the data sent.
-        /// </summary>
-        public new static ISet<HttpStatusCode> SUCCESS_CODES = new HashSet<HttpStatusCode>
-        {
-            HttpStatusCode.Accepted,
-            HttpStatusCode.Continue,
-            HttpStatusCode.Created,
-            HttpStatusCode.NoContent,
-            HttpStatusCode.OK
-        };
-
         private string _url;
-        public new string ContentType { get; set; } = "application/json";
 
         protected override string Name { get; } = typeof(AsyncWebEventReporter).Name;
 

--- a/GuaranteedRate.Sextant/WebClients/AsyncWebEventReporter.cs
+++ b/GuaranteedRate.Sextant/WebClients/AsyncWebEventReporter.cs
@@ -70,7 +70,7 @@ namespace GuaranteedRate.Sextant.WebClients
 
         }
 
-        protected  override bool PostEvent(object formattedData)
+        protected override bool PostEvent(object formattedData)
         {
             try
             {


### PR DESCRIPTION
Adding optional support for passing in tags in a Log statement to help provide additional details for shared loggers that are injected into different workflows (i.e. tasks) that can't provide workflow related values at initialization time when `Logger.Setup()` is called.

Also, cleared up a few build warnings in the process

- [x] Unit Tests
- [x] Changelog update
- [x] Version update
- [ ] Readme