### PR TITLE
[LOS-1955] Option to throw exception on loan open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v19.3.1.1 / 2019 October 18
+* **Update** - Optional parameter to throw exception when not able to open a loan
+
 ## v19.3.1.0 / 2019 September 5
 * **Add** - Optional tags for Logger methods `Info`, `Error`, `Warn`, `Debug`, and `Fatal`
 

--- a/GuaranteedRate.Sextant/EncompassUtils/SessionUtils.cs
+++ b/GuaranteedRate.Sextant/EncompassUtils/SessionUtils.cs
@@ -41,7 +41,14 @@ namespace GuaranteedRate.Sextant.EncompassUtils
             }
         }
 
-        public static Loan OpenLoan(Session session, string guid)
+        /// <summary>
+        /// Opens provided loan guid using the Session provided
+        /// </summary>
+        /// <param name="session">Connected session for opening the loan</param>
+        /// <param name="guid">Loan identifier</param>
+        /// <param name="throwOnError">Indicates whether errors should be thrown or if null is returned when an error occurs</param>
+        /// <returns>If success, the Loan object is returned. If unsuccessful and throwOnError is false, then null is returned</returns>
+        public static Loan OpenLoan(Session session, string guid, bool throwOnError = false)
         {
             if (!guid.StartsWith("{"))
             {
@@ -60,13 +67,22 @@ namespace GuaranteedRate.Sextant.EncompassUtils
             catch (Exception e)
             {
                 Console.WriteLine(e);
+                if (throwOnError) throw;
+
                 return null;
             }
         }
 
-        public static Loan OpenLoan(Session session, Guid guid)
+        /// <summary>
+        /// Opens provided loan guid using the Session provided
+        /// </summary>
+        /// <param name="session">Connected session for opening the loan</param>
+        /// <param name="guid">Loan identifier</param>
+        /// <param name="throwOnError">Indicates whether errors should be thrown or if null is returned when an error occurs</param>
+        /// <returns>If success, the Loan object is returned. If unsuccessful and throwOnError is false, then null is returned</returns>
+        public static Loan OpenLoan(Session session, Guid guid, bool throwOnError = false)
         {
-            return OpenLoan(session, guid.ToString("B"));
+            return OpenLoan(session, guid.ToString("B"), throwOnError);
         }
 
         /// <summary>

--- a/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
+++ b/GuaranteedRate.Sextant/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("19.3.1.0")]
-[assembly: AssemblyFileVersion("19.3.1.0")]
+[assembly: AssemblyVersion("19.3.1.1")]
+[assembly: AssemblyFileVersion("19.3.1.1")]


### PR DESCRIPTION
The current error handling for the `OpenLoan()` method is to just write to the console and return `null`.

This doesn't allow us to distinguish between "Loan not found" type errors, and errors that could be related to other types of Encompass issues.

By having the option to throw an exception on error, calling methods that want to distinguish between "Loan not found" and other errors can trap and handle different types of exceptions accordingly.

All existing code calling `OpenLoan()` without the new parameter will continue to just receive `null` without an exception when a problem occurs.