### PR TITLE
Update elasticsearch url

### DIFF
--- a/GuaranteedRate.Sextant.Integration.Tests/app.config
+++ b/GuaranteedRate.Sextant.Integration.Tests/app.config
@@ -4,7 +4,7 @@
 
     <!-- Logging -->
     <add key="ElasticsearchLogAppender.Enabled" value="true" />
-    <add key="ElasticsearchLogAppender.Url" value="https://elasticsearch.guaranteedrate.com:9200" />
+    <add key="ElasticsearchLogAppender.Url" value="https://elasticsearch.dev.platform.rate.com:9200" />
     <add key="ElasticsearchLogAppender.QueueSize" value="3" />
     <add key="ElasticsearchLogAppender.RetryLimit" value="3" />
     <add key="ElasticsearchLogAppender.All.Enabled" value="true" />


### PR DESCRIPTION
We want to move off of elasticsearch.guaranteedrate.com in favor of
elasticsearch.dev.platform.rate.com and elasticsearch.platform.rate.com.